### PR TITLE
[bugfix] StatusBox noCrd true 상태 표시 조건 변경

### DIFF
--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -270,7 +270,10 @@ export const Firehose = connect(
         );
         return <ConnectToState reduxes={reduxes}>{children}</ConnectToState>;
       }
-      return <StatusBox noCrd={true} />;
+      if (this.state.firehoses.length === 0) {
+        return <StatusBox noCrd={true} />
+      }
+      return null;
     }
   },
 );


### PR DESCRIPTION
firehoses 리스트가 0이면 firehose 에서 적절한 리소스를 찾지 못한 경우입니다.
이때, k8s 기본 리소스는 당연히 찾을 수 있다는 가정하에서, firehose 에서 적절한 리소스를 못찾은 경우는 crd가 존재하지 않는 경우라고 판단하여 현재 조건으로 설정 했습니다.
(명확하게 crd 임을 확정하는 조건은 조금 더 고민이 필요할듯 합니다.)