### PR TITLE
[feat][patch] 커스텀 폼 페이지와 yaml 폼 간 연동 기능 추가

### DIFF
--- a/frontend/public/components/hypercloud/crd/create-pinned-resource.tsx
+++ b/frontend/public/components/hypercloud/crd/create-pinned-resource.tsx
@@ -16,7 +16,7 @@ import { OperandForm } from '@console/operator-lifecycle-manager/src/components/
 import { OperandYAML } from '@console/operator-lifecycle-manager/src/components/operand/operand-yaml';
 import { DEFAULT_K8S_SCHEMA } from '@console/operator-lifecycle-manager/src/components/operand/const';
 import { prune } from '@console/shared/src/components/dynamic-form/utils';
-import { pluralToKind, isResourceSchemaBasedMenu, getResourceSchemaUrl } from '../form';
+import { pluralToKind, isResourceSchemaBasedMenu, getResourceSchemaUrl, shouldNotPruneMap } from '../form';
 import { ResourceLabel } from '../../../models/hypercloud/resource-plural';
 import { useTranslation } from 'react-i18next';
 import { coFetchJSON } from '@console/internal/co-fetch';
@@ -48,7 +48,7 @@ export const OnlyYamlEditorKinds = [
   models.CustomResourceDefinitionModel.kind,
 ];
 
-export const CreateDefault: React.FC<CreateDefaultProps> = ({ initialEditorType, loadError, match, model, activePerspective, create }) => {
+export const CreateDefault: React.FC<CreateDefaultProps> = ({ initialEditorType, loadError, match, model, activePerspective, create, customFormEditor }) => {
   const { t } = useTranslation();
   if (!model) {
     return null;
@@ -117,8 +117,9 @@ export const CreateDefault: React.FC<CreateDefaultProps> = ({ initialEditorType,
     }, [template, definition, model]);
 
     const sample = React.useMemo<K8sResourceKind>(() => exampleForModel(definition, model), [definition, model]);
+    const keysForsholdNotPrune = React.useMemo(() => shouldNotPruneMap.get(model.kind), [model]);
 
-    const pruneFunc = React.useCallback(data => prune(data, sample), [sample]);
+    const pruneFunc = React.useCallback(data => prune(data, sample, keysForsholdNotPrune), [sample, keysForsholdNotPrune]);
 
     const onChangeEditorType = React.useCallback(newMethod => {
       setHelpText(newMethod === EditorType.Form ? formHelpText : yamlHelpText);
@@ -139,7 +140,7 @@ export const CreateDefault: React.FC<CreateDefaultProps> = ({ initialEditorType,
                 formContext: { match, model, next, schema, create },
                 yamlContext: { next, match, create },
               }}
-              FormEditor={FormComponent}
+              FormEditor={customFormEditor || FormComponent}
               initialData={sample}
               initialType={initialEditorType}
               onChangeEditorType={onChangeEditorType}
@@ -179,16 +180,17 @@ export const CreateDefaultPage = connect(stateToProps)((props: CreateDefaultPage
 });
 
 export type CreateDefaultProps = {
-  activePerspective: string;
+  activePerspective?: string;
   initialEditorType: EditorType;
   loaded: boolean;
   loadError?: any;
-  match: RouterMatch<{ appName: string; ns: string; plural: K8sResourceKindReference }>;
+  match: RouterMatch<{ name: string; appName: string; ns: string; plural: K8sResourceKindReference }>;
   model: K8sKind;
   create: boolean;
+  customFormEditor?: React.FC<any>;
 };
 
 export type CreateDefaultPageProps = {
-  match: RouterMatch<{ appName: string; ns: string; plural: K8sResourceKindReference }>;
+  match: RouterMatch<{ name: string; appName: string; ns: string; plural: K8sResourceKindReference }>;
   model: K8sKind;
 };

--- a/frontend/public/components/hypercloud/crd/index.tsx
+++ b/frontend/public/components/hypercloud/crd/index.tsx
@@ -1,6 +1,7 @@
 // import * as React from 'react';
 import * as _ from 'lodash';
 import { K8sKind, CustomResourceDefinitionKind, referenceFor, referenceForModel } from '@console/internal/module/k8s';
+import { defaultTemplateMap } from '../form';
 
 export const parseALMExamples = (crd: CustomResourceDefinitionKind) => {
   try {
@@ -14,6 +15,7 @@ export const parseALMExamples = (crd: CustomResourceDefinitionKind) => {
 
 export const exampleForModel = (crd: CustomResourceDefinitionKind, model: K8sKind) => {
   const almObj = parseALMExamples(crd);
+  const defaultTemplate = defaultTemplateMap.get(model.kind) || {};
   return _.defaultsDeep(
     {},
     {
@@ -21,5 +23,6 @@ export const exampleForModel = (crd: CustomResourceDefinitionKind, model: K8sKin
       apiVersion: model?.apiGroup ? `${model.apiGroup}/${model.apiVersion}` : `${model.apiVersion}`,
     },
     _.find(almObj, (s: CustomResourceDefinitionKind) => referenceFor(s) === referenceForModel(model)),
+    defaultTemplate,
   );
 };

--- a/frontend/public/components/hypercloud/form/index.ts
+++ b/frontend/public/components/hypercloud/form/index.ts
@@ -62,3 +62,18 @@ export const getResourceSchemaUrl = (model: K8sKind, isCustomResourceType: boole
   }
   return url;
 };
+
+// 폼 생성 시 기본값으로 포함되어야할 템플릿 정의
+export const defaultTemplateMap = new Map([
+  [
+    models.TaskModel.kind,
+    {
+      metadata: {
+        name: 'example-name',
+      },
+    },
+  ],
+]);
+
+// 빈 값으로 정의되어야 하는 것들 정의
+export const shouldNotPruneMap = new Map([[models.TaskModel.kind, ['emptyDir']]]);

--- a/frontend/public/components/hypercloud/utils/button-state.tsx
+++ b/frontend/public/components/hypercloud/utils/button-state.tsx
@@ -15,7 +15,7 @@ const isNotAllowedStatus = (statusList, currentStatus) => {
 };
 
 export const isSaveButtonDisabled = obj => {
-  let kind = obj.kind;
+  let kind = obj?.kind;
   let status = ''; // 리소스마다 status 위치 다름
   switch (kind) {
     case TFApplyClaimModel.kind:


### PR DESCRIPTION
- `dynamic-form/utils.ts` : 특정 필드들에 한해 빈 값이어도 값이 제거되지 않도록 기능 추가
- `생성 공통 폼`(create-pinned-resource.tsx) 및 `수정 공통 폼`(edit-resource.tsx)에 커스텀 폼 prop 추가
- `생성 커스텀 폼`(create-forrm.tsx) : form과 yaml간 데이터 동기화 기능 추가

![image](https://user-images.githubusercontent.com/29051383/191932295-5e244157-5f3b-4f11-859b-5e10cfe3973c.png)
