### PR TITLE
[bugfix] 파이프라인 리소스 - Form 뷰 레이블, Yaml 뷰 apiVersoin 오류 수정

### DIFF
--- a/frontend/public/components/hypercloud/form/pipelineresources/create-pipelineresource.tsx
+++ b/frontend/public/components/hypercloud/form/pipelineresources/create-pipelineresource.tsx
@@ -17,8 +17,11 @@ import { convertToForm, onSubmitCallback } from './sync-form-data';
 import { defaultTemplateMap } from '@console/internal/components/hypercloud/form';
 
 const CreatePipelineResourceComponent: React.FC<PipelineResourceFormProps> = props => {
+  const { formData } = props;
   const { control } = useFormContext();
   const { t } = useTranslation();
+
+  const [labels] = React.useState(formData?.metadata?.labels || []);
 
   const typeList = { git: t('SINGLE:MSG_PIPELINERESOURCES_CREATEFORM_7'), image: t('SINGLE:MSG_PIPELINERESOURCES_CREATEFORM_8') };
   const type = useWatch({
@@ -50,7 +53,7 @@ const CreatePipelineResourceComponent: React.FC<PipelineResourceFormProps> = pro
   return (
     <>
       <Section label={t('SINGLE:MSG_PIPELINERESOURCES_CREATEFORM_2')} id="label" description={t('SINGLE:MSG_PIPELINERESOURCES_CREATEFORM_3')}>
-        <Controller name="metadata.labels" id="label" labelClassName="co-text-sample" as={SelectorInput} control={control} tags={[]} />
+        <Controller name="metadata.labels" id="label" labelClassName="co-text-sample" as={SelectorInput} control={control} tags={labels} />
       </Section>
 
       <Section label={t('SINGLE:MSG_PIPELINERESOURCES_CREATEFORM_4')} id="type" description={t('SINGLE:MSG_PIPELINERESOURCES_CREATEFORM_10')}>
@@ -114,4 +117,5 @@ type PipelineResourceFormProps = {
     [key: string]: string;
   };
   isCreate: boolean;
+  formData: any;
 };

--- a/frontend/public/components/hypercloud/form/pipelineresources/sync-form-data.ts
+++ b/frontend/public/components/hypercloud/form/pipelineresources/sync-form-data.ts
@@ -1,15 +1,13 @@
 import * as _ from 'lodash-es';
 import { SelectorInput } from '@console/internal/components/utils';
+import { PipelineResourceModel } from '@console/internal/models/hypercloud';
 
 export const onSubmitCallback = data => {
-  let labels = SelectorInput.objectify(data.metadata.labels);
-  if (_.isArray(data.metadata.labels)) {
-    data.metadata.labels.forEach(cur => {
-      labels = typeof cur === 'string' ? SelectorInput.objectify(data.metadata.labels) : data.metadata.labels;
-    });
-  } else {
-    labels = typeof data.metadata.labels === 'string' ? SelectorInput.objectify(data.metadata.labels) : data.metadata.labels;
+  if (_.isEmpty(data)) {
+    return data;
   }
+
+  let labels = SelectorInput.objectify(data.metadata.labels);
 
   let params = [];
   data.spec.revision && params.push({ name: 'revision', value: data.spec.revision });
@@ -19,6 +17,9 @@ export const onSubmitCallback = data => {
   delete data.spec.params;
   delete data.spec.revision;
   delete data.spec.url;
+
+  data.kind = PipelineResourceModel.kind;
+  data.apiVersion = `${PipelineResourceModel.apiGroup}/${PipelineResourceModel.apiVersion}`;
 
   data = _.defaultsDeep({ metadata: { labels: labels }, spec: { params: params } }, data);
   return data;

--- a/frontend/public/components/hypercloud/pipeline-resource.tsx
+++ b/frontend/public/components/hypercloud/pipeline-resource.tsx
@@ -81,7 +81,7 @@ const PipelineResourceDetails: React.FC<PipelineResourceDetailsProps> = ({ obj: 
   );
 };
 
-const { details, editResource, editYaml } = navFactory;
+const { details, editResource } = navFactory;
 
 export const PipelineResources: React.FC = props => {
   const { t } = useTranslation();
@@ -95,7 +95,7 @@ export const PipelineResourcesPage: React.FC<PipelineResourcesPageProps> = props
   return <ListPage title={t('COMMON:MSG_LNB_MENU_62')} createButtonText={t('COMMON:MSG_MAIN_CREATEBUTTON_1', { 0: t('COMMON:MSG_LNB_MENU_62') })} canCreate={true} ListComponent={PipelineResources} kind={kind} {...props} />;
 };
 
-export const PipelineResourcesDetailsPage: React.FC<PipelineResourcesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(PipelineResourceDetails)), editResource(), editYaml()]} />;
+export const PipelineResourcesDetailsPage: React.FC<PipelineResourcesDetailsPageProps> = props => <DetailsPage {...props} kind={kind} menuActions={menuActions} pages={[details(detailsPage(PipelineResourceDetails)), editResource()]} />;
 
 type PipelineResourcesPageProps = {
   showTitle?: boolean;


### PR DESCRIPTION
Form 뷰에서 레이블이 제대로 작동하지 않는 오류 수정.
Yaml 뷰에서 kind, apiVersion이 누락되었던 오류 수정.
YAML 탭 제거