### PR TITLE
IMS [290316] 시크릿 키/값 시크릿 생성시, 수정시 평문으로 안내 문구 추가 및 시크릿 키/값 상세 보기시 데이터값 표시에 토큰값을 64 인코딩하여 적용

### DIFF
--- a/frontend/public/components/configmap-and-secret-data.tsx
+++ b/frontend/public/components/configmap-and-secret-data.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Base64 } from 'js-base64';
+// import { Base64 } from 'js-base64';
 import { saveAs } from 'file-saver';
 import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
 import { Button } from '@patternfly/react-core';
@@ -29,17 +29,12 @@ export const ConfigMapBinaryData: React.FC<DownloadValueProps> = ({ data }) => {
   const dl = [];
   Object.keys(data || {})
     .sort()
-    .forEach((k) => {
+    .forEach(k => {
       const value = data[k];
       dl.push(<dt key={`${k}-k`}>{k}</dt>);
       dl.push(
         <dd key={`${k}-v`}>
-          <Button
-            className="pf-m-link--align-left"
-            type="button"
-            onClick={() => downloadBinary(k, value)}
-            variant="link"
-          >
+          <Button className="pf-m-link--align-left" type="button" onClick={() => downloadBinary(k, value)} variant="link">
             Save File
           </Button>
         </dd>,
@@ -53,7 +48,7 @@ export const ConfigMapData: React.FC<ConfigMapDataProps> = ({ data, label }) => 
   const dl = [];
   Object.keys(data || {})
     .sort()
-    .forEach((k) => {
+    .forEach(k => {
       const value = data[k];
       dl.push(<dt key={`${k}-k`}>{k}</dt>);
       dl.push(
@@ -71,9 +66,9 @@ export const SecretValue: React.FC<SecretValueProps> = ({ value, reveal, encoded
     return <span className="text-muted">No value</span>;
   }
 
-  const decodedValue = encoded ? Base64.decode(value) : value;
-  const visibleValue = reveal ? decodedValue : <MaskedData />;
-  return <CopyToClipboard value={decodedValue} visibleValue={visibleValue} />;
+  // const decodedValue = encoded ? Base64.decode(value) : value;
+  const visibleValue = reveal ? value : <MaskedData />;
+  return <CopyToClipboard value={value} visibleValue={visibleValue} />;
 };
 SecretValue.displayName = 'SecretValue';
 
@@ -84,7 +79,7 @@ export const SecretData: React.FC<SecretDataProps> = ({ data, title = 'Data' }) 
   const dl = [];
   Object.keys(data || {})
     .sort()
-    .forEach((k) => {
+    .forEach(k => {
       dl.push(<dt key={`${k}-k`}>{k}</dt>);
       dl.push(
         <dd key={`${k}-v`}>
@@ -97,12 +92,7 @@ export const SecretData: React.FC<SecretDataProps> = ({ data, title = 'Data' }) 
     <>
       <SectionHeading text={t('COMMON:MSG_DETAILS_TABDETAILS_DATA_1')}>
         {dl.length ? (
-          <Button
-            type="button"
-            onClick={() => setReveal(!reveal)}
-            variant="link"
-            className="pf-m-link--align-right"
-          >
+          <Button type="button" onClick={() => setReveal(!reveal)} variant="link" className="pf-m-link--align-right">
             {reveal ? (
               <>
                 <EyeSlashIcon className="co-icon-space-r" />

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -976,7 +976,6 @@ const KeyValueEntryForm = withTranslation()(
           <div className="form-group">
             <div>
               <DroppableFileInput onChange={this.onValueChange} inputFileData={this.state.value} id={`${this.props.id}-value`} textareaFieldHelpText={t('SINGLE:MSG_SECRETS_CREATEFORM_DIV2_1')} label={t('SINGLE:MSG_SECRETS_CREATEKEYVALUESECRET_DIV2_4')} inputFieldHelpText={t('SINGLE:MSG_SECRETS_CREATEKEYVALUESECRET_DIV2_6')} />
-              <p className="co-m-pane__explanation">{t('SINGLE:MSG_SECRETS_CREATEFORM_DIV2_1')}</p>
             </div>
           </div>
         </div>

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -975,7 +975,7 @@ const KeyValueEntryForm = withTranslation()(
           </div>
           <div className="form-group">
             <div>
-              <DroppableFileInput onChange={this.onValueChange} inputFileData={this.state.value} id={`${this.props.id}-value`} label={t('SINGLE:MSG_SECRETS_CREATEKEYVALUESECRET_DIV2_4')} inputFieldHelpText={t('SINGLE:MSG_SECRETS_CREATEKEYVALUESECRET_DIV2_6')} />
+              <DroppableFileInput onChange={this.onValueChange} inputFileData={this.state.value} id={`${this.props.id}-value`} textareaFieldHelpText={t('SINGLE:MSG_SECRETS_CREATEFORM_DIV2_1')} label={t('SINGLE:MSG_SECRETS_CREATEKEYVALUESECRET_DIV2_4')} inputFieldHelpText={t('SINGLE:MSG_SECRETS_CREATEKEYVALUESECRET_DIV2_6')} />
               <p className="co-m-pane__explanation">{t('SINGLE:MSG_SECRETS_CREATEFORM_DIV2_1')}</p>
             </div>
           </div>

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -976,6 +976,7 @@ const KeyValueEntryForm = withTranslation()(
           <div className="form-group">
             <div>
               <DroppableFileInput onChange={this.onValueChange} inputFileData={this.state.value} id={`${this.props.id}-value`} label={t('SINGLE:MSG_SECRETS_CREATEKEYVALUESECRET_DIV2_4')} inputFieldHelpText={t('SINGLE:MSG_SECRETS_CREATEKEYVALUESECRET_DIV2_6')} />
+              <p className="co-m-pane__explanation">{t('SINGLE:MSG_SECRETS_CREATEFORM_DIV2_1')}</p>
             </div>
           </div>
         </div>

--- a/scripts/run-console.sh
+++ b/scripts/run-console.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 set -exuo pipefail
-myIP='192.168.8.106'
-# myIP=$(hostname -I | awk '{print $1}')
+myIP=$(hostname -I | awk '{print $1}')
 #myIP=$(ipconfig getifaddr en0)
 # myIP=localhost
 ## Default K8S Endpoint is public POC environment

--- a/scripts/run-console.sh
+++ b/scripts/run-console.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 set -exuo pipefail
-
-myIP=$(hostname -I | awk '{print $1}')
+myIP='192.168.8.106'
+# myIP=$(hostname -I | awk '{print $1}')
 #myIP=$(ipconfig getifaddr en0)
 # myIP=localhost
 ## Default K8S Endpoint is public POC environment

--- a/scripts/run-console.sh
+++ b/scripts/run-console.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -exuo pipefail
+
 myIP=$(hostname -I | awk '{print $1}')
 #myIP=$(ipconfig getifaddr en0)
 # myIP=localhost


### PR DESCRIPTION
#### What:[IMS] 290316 에 시크릿 키/값 시크릿 생성시 평문으로 추가안내 문구 추가 했습니다.
#### Why: [IMS] 290316에 '추가된 값을 직접 입력할 경우 평문으로 입력해 주세요.' 를 추가했습니다.
#### How: '값을 직접 입력할 경우 평문으로 입력해 주세요.' 를 필요 지점에 넣었습니다.