### PR TITLE
싱글 클러스터 네트워크 전송 오류 수정을 위한 쿼리 수정 및 알고리즘 수정

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/node-dashboard/queries.ts
+++ b/frontend/packages/console-app/src/components/nodes/node-dashboard/queries.ts
@@ -44,13 +44,13 @@ const top25Queries = {
   [NodeQueries.PODS_BY_CPU]: _.template(`topk(25, sort_desc(sum(rate(container_cpu_usage_seconds_total{container="",pod!="", instance=~'<%= ipAddress %>:.*'}[5m])) by (pod, namespace)))`),
   [NodeQueries.PODS_BY_MEMORY]: _.template(`topk(25, sort_desc(sum(avg_over_time(container_memory_working_set_bytes{container="",pod!="",instance=~'<%= ipAddress %>:.*'}[5m])) BY (pod, namespace)))`),
   [NodeQueries.PODS_BY_FILESYSTEM]: _.template(`topk(25, sort_desc(sum(container_fs_usage_bytes{instance=~'<%= ipAddress %>:.*'}) BY (pod, namespace)))`),
-  [NodeQueries.PODS_BY_NETWORK_IN]: _.template(`topk(25, sort_desc(sum(rate(container_network_receive_bytes_total{ container="POD", pod!= "", instance=~'<%= ipAddress %>:.*'}[5m])) BY (pod, namespace)))`),
-  [NodeQueries.PODS_BY_NETWORK_OUT]: _.template(`topk(25, sort_desc(sum(rate(container_network_transmit_bytes_total{ container="POD", pod!= "", instance=~'<%= ipAddress %>:.*'}[5m])) BY (pod, namespace)))`),
+  [NodeQueries.PODS_BY_NETWORK_IN]: _.template(`topk(25, sort_desc(sum(rate(container_network_receive_bytes_total{ pod!= "", instance=~'<%= ipAddress %>:.*'}[5m])) BY (pod, namespace)))`),
+  [NodeQueries.PODS_BY_NETWORK_OUT]: _.template(`topk(25, sort_desc(sum(rate(container_network_transmit_bytes_total{ pod!= "", instance=~'<%= ipAddress %>:.*'}[5m])) BY (pod, namespace)))`),
   [NodeQueries.PROJECTS_BY_CPU]: _.template(`topk(25, sort_desc(sum(rate(container_cpu_usage_seconds_total{container="",pod!="", instance=~'<%= ipAddress %>:.*'}[5m])) by (namespace)))`),
   [NodeQueries.PROJECTS_BY_MEMORY]: _.template(`topk(25, sort_desc(sum(avg_over_time(container_memory_working_set_bytes{container="",pod!="",instance=~'<%= ipAddress %>:.*'}[5m])) BY (namespace)))`),
   [NodeQueries.PROJECTS_BY_FILESYSTEM]: _.template(`topk(25, sort_desc(sum(container_fs_usage_bytes{instance=~'<%= ipAddress %>:.*'}) BY (namespace)))`),
-  [NodeQueries.PROJECTS_BY_NETWORK_IN]: _.template(`topk(25, sort_desc(sum(rate(container_network_receive_bytes_total{ container="POD", pod!= "", instance=~'<%= ipAddress %>:.*'}[5m])) BY (namespace)))`),
-  [NodeQueries.PROJECTS_BY_NETWORK_OUT]: _.template(`topk(25, sort_desc(sum(rate(container_network_transmit_bytes_total{ container="POD", pod!= "", instance=~'<%= ipAddress %>:.*'}[5m])) BY (namespace)))`),
+  [NodeQueries.PROJECTS_BY_NETWORK_IN]: _.template(`topk(25, sort_desc(sum(rate(container_network_receive_bytes_total{ pod!= "", instance=~'<%= ipAddress %>:.*'}[5m])) BY (namespace)))`),
+  [NodeQueries.PROJECTS_BY_NETWORK_OUT]: _.template(`topk(25, sort_desc(sum(rate(container_network_transmit_bytes_total{ pod!= "", instance=~'<%= ipAddress %>:.*'}[5m])) BY (namespace)))`),
 };
 
 const resourceQuotaQueries = {

--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
@@ -41,7 +41,7 @@ export const MultilineUtilizationItem: React.FC<MultilineUtilizationItemProps> =
       <div className="co-utilization-card__item-description">
         <div className="co-utilization-card__item-section-multiline">
           <h4 className="pf-c-title pf-m-md">{title}</h4>
-          {error || (!isLoading && !data.every(datum => datum.length)) ? <div className="text-secondary">{t('SINGLE:MSG_OVERVIEW_MAIN_CARDSTATUS_1')}</div> : <div className="co-utilization-card__item-description">{currentValue}</div>}
+          {error || (isLoading && !data.every(datum => datum.length)) ? <div className="text-secondary">{t('SINGLE:MSG_OVERVIEW_MAIN_CARDSTATUS_1')}</div> : <div className="co-utilization-card__item-description">{currentValue}</div>}
         </div>
       </div>
       <div className="co-utilization-card__item-chart">{chart}</div>

--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
@@ -41,7 +41,7 @@ export const MultilineUtilizationItem: React.FC<MultilineUtilizationItemProps> =
       <div className="co-utilization-card__item-description">
         <div className="co-utilization-card__item-section-multiline">
           <h4 className="pf-c-title pf-m-md">{title}</h4>
-          {error || (isLoading && !data.every(datum => datum.length)) ? <div className="text-secondary">{t('SINGLE:MSG_OVERVIEW_MAIN_CARDSTATUS_1')}</div> : <div className="co-utilization-card__item-description">{currentValue}</div>}
+          {error || (!isLoading && !data.every(datum => datum.length)) ? <div className="text-secondary">{t('SINGLE:MSG_OVERVIEW_MAIN_CARDSTATUS_1')}</div> : <div className="co-utilization-card__item-description">{currentValue}</div>}
         </div>
       </div>
       <div className="co-utilization-card__item-chart">{chart}</div>

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/queries.ts
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/queries.ts
@@ -51,8 +51,8 @@ const top25Queries = {
 const overviewQueries = {
   [OverviewQuery.MEMORY_TOTAL]: 'sum(node_memory_MemTotal_bytes{cluster=""})',
   [OverviewQuery.MEMORY_UTILIZATION]: 'sum(node_memory_MemTotal_bytes{cluster=""} - node_memory_MemAvailable_bytes{cluster=""})',
-  [OverviewQuery.NETWORK_IN_UTILIZATION]: 'sum(rate(container_network_receive_bytes_total{container="POD",pod!=""}[5m]))',
-  [OverviewQuery.NETWORK_OUT_UTILIZATION]: 'sum(rate(container_network_transmit_bytes_total{container="POD",pod!=""}[5m]))',
+  [OverviewQuery.NETWORK_IN_UTILIZATION]: 'sum(rate(container_network_receive_bytes_total{pod!=""}[5m]))',
+  [OverviewQuery.NETWORK_OUT_UTILIZATION]: 'sum(rate(container_network_transmit_bytes_total{pod!=""}[5m]))',
   [OverviewQuery.NETWORK_UTILIZATION]: 'sum(instance:node_network_transmit_bytes_excluding_lo:rate1m+instance:node_network_receive_bytes_excluding_lo:rate1m)',
   [OverviewQuery.CPU_UTILIZATION]: 'sum(instance:node_cpu:rate:sum{cluster=""})',
   [OverviewQuery.CPU_TOTAL]: 'sum(count(node_cpu_seconds_total{job="node-exporter",mode="idle"}) by(instance))',


### PR DESCRIPTION
#### What:[IMS] 290595(싱글클러스터 선택시 네트워크 그래프와 상태를 볼수없음) 를 해결하기 위해 쿼리를 수정하고 또 로딩 알고리즘에 오류가 있어서 로딩이 아닌상황에 "사용불가" 가 나오는 오류를 수정했습니다.

#### Why:[IMS] 290595 싱글클러스터 선택시 네트워크 그래프와 상태를 볼수없음을 수정했습니다.

#### How: 쿼리를 수정했고 네트워크 사용불가 관련 삼항연상자를 수정했습니다.