### PR TITLE
[feat] crd 화면 기획문서와 다른부분 수정

### DIFF
--- a/frontend/public/components/utils/status-box.tsx
+++ b/frontend/public/components/utils/status-box.tsx
@@ -91,8 +91,8 @@ export const CrdNotFound: React.FC<CrdNotFoundProps> = ({ message }) => {
     <div>
       <Box className="text-center">
         <img className="cos-status-box__access-denied-icon" src={imgNoResource} />
-        <MsgBox title={t('COMMON:MSG_COMMON_ERROR_MESSAGE_29')} detail={t('COMMON:MSG_COMMON_ERROR_MESSAGE_42')} className="co-pre-wrap" />
-        <Link to={'/k8s/cluster/customresourcedefinitions'}>{t('COMMON:MSG_COMMON_ERROR_MESSAGE_43')}</Link>
+        <MsgBox title={t('COMMON:MSG_COMMON_ERROR_MESSAGE_42').split('\n')[0]} detail={t('COMMON:MSG_COMMON_ERROR_MESSAGE_42').split('\n')[1]} className="co-pre-wrap" />
+        <Link to={'/k8s/cluster/customresourcedefinitions/~new'}>{t('COMMON:MSG_COMMON_ERROR_MESSAGE_43')}</Link>
       </Box>
       {_.isString(message) && (
         <Alert isInline className="co-alert co-alert-space" variant="danger" title={t('COMMON:MSG_MAIN_POPOVER_1')}>


### PR DESCRIPTION
#### What:crd 화면 기획문서와 다른부분을 수정하였습니다.

#### Why: 기획문서와 다른 여러가지 내용들을 수정하였습니다.

#### How: 기획 문서에 적힌 대로 데이터를 생성할 수 없습니다. 대신 "이 메뉴에 사용자 리소스 정의가 없습니다."
"서비스를 이용하기 위해 사용자 리소스 정의를 생성해 주세요." 를 각각 제목, 상세설명에 넣었습니다.
리스트 정의 생성하기 링크를 누르면 리소스 정의 리스트 페이지가 랜더링 되던 것을 
리소스 정의 생성페이지로 넘어가게 수정했습니다.
crd 화면이 기획문서와 다른것이 발견되어 이를 수정하였습니다.

직접 cr를 만들어 확인하면서 구현을 하였습니다. 

<img width="716" alt="image" src="https://user-images.githubusercontent.com/82989054/202998894-9319ba02-c27e-4b31-aafa-07ff0d767bbb.png">


CR을 만들어서 화면을 띄워 보니 빨간 글씨가 쳐저 있는 부분과

리스트 정의 생성하기 링크를 누르면 리소스 정의 생성페이지가 아니라 리소스 정의 리스트 페이지가 랜더링되었습니다. 

<img width="707" alt="image" src="https://user-images.githubusercontent.com/82989054/202999169-1793cd4a-32ef-4459-a007-f8ec564bb08a.png">
<img width="1077" alt="image" src="https://user-images.githubusercontent.com/82989054/202999869-332a7efc-012c-46b3-962a-759870e582be.png">


이를 수정하여 바꾸었습니다.
<img width="702" alt="스크린샷 2022-11-21 오후 5 18 47" src="https://user-images.githubusercontent.com/82989054/202999328-724bc51a-b311-4bed-b128-328fe5590ed7.png">

