### PR TITLE
[feat][patch][IMS 294273] 헬름차트 메뉴에서 이름 중복 리소스 가져오지 않는 현상 수정

### DIFF
--- a/frontend/public/reducers/k8s.ts
+++ b/frontend/public/reducers/k8s.ts
@@ -49,8 +49,8 @@ const loadList = (oldList, resources, id?) => {
   const existingKeys = new Set(oldList.keys());
   return oldList.withMutations(list => {
     (resources || []).forEach(r => {
-      const repoNmae = r.repo?.name ? r.repo.name : '';
-      const qualifiedName = isNonK8SResource(id) ? (r.namespace ? `(${r.namespace})-` : '') + r.name + repoNmae : getQN(r);
+      const repoName = r.repo?.name ? r.repo.name : '';
+      const qualifiedName = isNonK8SResource(id) ? (r.namespace ? `(${r.namespace})-` : '') + r.name + repoName : getQN(r);
 
       existingKeys.delete(qualifiedName);
       const next = fromJS(r);

--- a/frontend/public/reducers/k8s.ts
+++ b/frontend/public/reducers/k8s.ts
@@ -49,7 +49,9 @@ const loadList = (oldList, resources, id?) => {
   const existingKeys = new Set(oldList.keys());
   return oldList.withMutations(list => {
     (resources || []).forEach(r => {
-      const qualifiedName = isNonK8SResource(id) ? (r.namespace ? `(${r.namespace})-` : '') + r.name + r.created + r.repo.name : getQN(r);
+      const repoNmae = r.repo?.name ? r.repo.name : '';
+      const qualifiedName = isNonK8SResource(id) ? (r.namespace ? `(${r.namespace})-` : '') + r.name + repoNmae : getQN(r);
+
       existingKeys.delete(qualifiedName);
       const next = fromJS(r);
       const current = list.get(qualifiedName);

--- a/frontend/public/reducers/k8s.ts
+++ b/frontend/public/reducers/k8s.ts
@@ -49,7 +49,7 @@ const loadList = (oldList, resources, id?) => {
   const existingKeys = new Set(oldList.keys());
   return oldList.withMutations(list => {
     (resources || []).forEach(r => {
-      const qualifiedName = isNonK8SResource(id) ? (r.namespace ? `(${r.namespace})-` : '') + r.name + r.created : getQN(r);
+      const qualifiedName = isNonK8SResource(id) ? (r.namespace ? `(${r.namespace})-` : '') + r.name + r.created + r.repo.name : getQN(r);
       existingKeys.delete(qualifiedName);
       const next = fromJS(r);
       const current = list.get(qualifiedName);

--- a/frontend/public/reducers/k8s.ts
+++ b/frontend/public/reducers/k8s.ts
@@ -37,11 +37,7 @@ const updateList = (list: ImmutableMap<string, any>, nextJS: K8sResourceKind) =>
 
   // TODO: (kans) only store the data for things we display ...
   //  and then only do this comparison for the same stuff!
-  if (
-    current
-      .deleteIn(['metadata', 'resourceVersion'])
-      .equals(next.deleteIn(['metadata', 'resourceVersion']))
-  ) {
+  if (current.deleteIn(['metadata', 'resourceVersion']).equals(next.deleteIn(['metadata', 'resourceVersion']))) {
     // If the only thing that differs is resource version, don't fire an update.
     return list;
   }
@@ -51,17 +47,19 @@ const updateList = (list: ImmutableMap<string, any>, nextJS: K8sResourceKind) =>
 
 const loadList = (oldList, resources, id?) => {
   const existingKeys = new Set(oldList.keys());
-  return oldList.withMutations((list) => {
-    (resources || []).forEach((r) => {
-      const qualifiedName = isNonK8SResource(id) ? (r.namespace ? `(${r.namespace})-` : '') + r.name : getQN(r);
+  return oldList.withMutations(list => {
+    (resources || []).forEach(r => {
+      const qualifiedName = isNonK8SResource(id) ? (r.namespace ? `(${r.namespace})-` : '') + r.name + r.created : getQN(r);
       existingKeys.delete(qualifiedName);
       const next = fromJS(r);
       const current = list.get(qualifiedName);
+
       if (!current || isNonK8SResource(id) ? true : moreRecent(next, current)) {
         list.set(qualifiedName, next);
       }
     });
-    existingKeys.forEach((k) => {
+
+    existingKeys.forEach(k => {
       const r = list.get(k);
       const metadata = isNonK8SResource(id) ? {} : r.get('metadata').toJSON();
       if (!metadata.deletionTimestamp) {
@@ -93,24 +91,20 @@ export default (state: K8sState, action: K8sAction): K8sState => {
     case ActionType.ReceivedResources:
       return (
         action.payload.resources.models
-          .filter((model) => !state.getIn(['RESOURCES', 'models']).has(referenceForModel(model)))
-          .filter((model) => {
+          .filter(model => !state.getIn(['RESOURCES', 'models']).has(referenceForModel(model)))
+          .filter(model => {
             const existingModel = state.getIn(['RESOURCES', 'models', model.kind]);
             return !existingModel || referenceForModel(existingModel) !== referenceForModel(model);
           })
-          .map((model) => {
-            model.namespaced
-              ? namespacedResources.add(referenceForModel(model))
-              : namespacedResources.delete(referenceForModel(model));
+          .map(model => {
+            model.namespaced ? namespacedResources.add(referenceForModel(model)) : namespacedResources.delete(referenceForModel(model));
             return model;
           })
           .reduce((prevState, newModel) => {
             // FIXME: Need to use `kind` as model reference for legacy components accessing k8s primitives
-            const [modelRef, model] = allModels().findEntry(
-              (staticModel) => referenceForModel(staticModel) === referenceForModel(newModel),
-            ) || [referenceForModel(newModel), newModel];
+            const [modelRef, model] = allModels().findEntry(staticModel => referenceForModel(staticModel) === referenceForModel(newModel)) || [referenceForModel(newModel), newModel];
             // Verbs and short names are not part of the static model definitions, so use the values found during discovery.
-            return prevState.updateIn(['RESOURCES', 'models'], (models) =>
+            return prevState.updateIn(['RESOURCES', 'models'], models =>
               models.set(modelRef, {
                 ...model,
                 verbs: newModel.verbs,
@@ -197,14 +191,14 @@ export default (state: K8sState, action: K8sAction): K8sState => {
     case ActionType.UpdateListFromWS:
       newList = state.getIn([action.payload.id, 'data']);
       // HelmRelease WS update
-      if(action.payload.id === 'HelmRelease') {
+      if (action.payload.id === 'HelmRelease') {
         const listObject: any = action.payload.k8sObjects[0];
         newList = newList.clear();
         listObject.release.forEach(r => {
           const qualifiedName = (r.namespace ? `(${r.namespace})-` : '') + r.name;
           const next = fromJS(r);
           newList = newList.set(qualifiedName, next);
-        });        
+        });
         break;
       }
       // k8sObjects is an array of k8s WS Events
@@ -229,14 +223,7 @@ export default (state: K8sState, action: K8sAction): K8sState => {
       if (!state.getIn([action.payload.id, 'data'])) {
         return state;
       }
-      newList = state
-        .getIn([action.payload.id, 'data'])
-        .merge(
-          action.payload.k8sObjects.reduce(
-            (map, obj) => map.set(getQN(obj), fromJS(obj)),
-            ImmutableMap(),
-          ),
-        );
+      newList = state.getIn([action.payload.id, 'data']).merge(action.payload.k8sObjects.reduce((map, obj) => map.set(getQN(obj), fromJS(obj)), ImmutableMap()));
       break;
     case ActionType.Errored:
       if (!state.getIn([action.payload.id, 'data'])) {


### PR DESCRIPTION
#### What: 헬름차트 메뉴에서 이름 중복 리소스 가져오지 않는 현상을 수정했습니다.

#### Why: IMS 294273로 문제를 전달 받았습니다.

#### How: list.set(qualifiedName, next); 부분에서 qualifiedName이 중복이 된다면 같은 이름의 네임을 가진 리소스가  없어집니다.
created인자를 추가하여 유니크하게 리소스를 추가 할수 있게 하였습니다. 이전에는 하나만 볼수있었던 harbor 를 2개 다 볼수 있게 되었습니다.
<img width="757" alt="스크린샷 2022-11-28 오전 10 15 13" src="https://user-images.githubusercontent.com/82989054/204171804-37892ced-a33a-4870-b888-ebea0fa9d7de.png">

<img width="615" alt="스크린샷 2022-11-28 오전 10 12 07" src="https://user-images.githubusercontent.com/82989054/204171766-0644870e-d540-4592-a289-6c72dde40923.png">
