### PR TITLE
[feat][patch][IMS 290316] 콘솔 시크릿 정보 표시 관련 ui 재적용 및 수정시 다른 값이 영향받는 현상 수정

### DIFF
--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -123,9 +123,12 @@ export const withSecretForm = (SubForm, modal?: boolean) =>
           inProgress: false,
           type: defaultSecretType,
           stringData: _.mapValues(_.get(props.obj, 'data'), value => {
-            return value ? Base64.decode(value) : '';
+            return '';
           }),
           disableForm: false,
+          originData: _.mapValues(_.get(props.obj, 'data'), value => {
+            return value ? Base64.decode(value) : '';
+          }),
         };
         this.onDataChanged = this.onDataChanged.bind(this);
         this.onNameChanged = this.onNameChanged.bind(this);
@@ -162,6 +165,9 @@ export const withSecretForm = (SubForm, modal?: boolean) =>
         e.preventDefault();
         const { metadata } = this.state.secret;
         this.setState({ inProgress: true });
+        for (const [key, value] of Object.entries(this.state.stringData)) {
+          value === '' && (this.state.stringData[key] = this.state.originData[key]);
+        }
         const newSecret = _.assign({}, this.state.secret, { stringData: this.state.stringData }, { type: this.state.type });
         (this.props.isCreate ? k8sCreate(SecretModel, newSecret) : k8sUpdate(SecretModel, newSecret, metadata.namespace, newSecret.metadata.name)).then(
           secret => {
@@ -975,7 +981,7 @@ const KeyValueEntryForm = withTranslation()(
           </div>
           <div className="form-group">
             <div>
-              <DroppableFileInput onChange={this.onValueChange} inputFileData={this.state.value} id={`${this.props.id}-value`} textareaFieldHelpText={t('SINGLE:MSG_SECRETS_CREATEFORM_DIV2_1')} label={t('SINGLE:MSG_SECRETS_CREATEKEYVALUESECRET_DIV2_4')} inputFieldHelpText={t('SINGLE:MSG_SECRETS_CREATEKEYVALUESECRET_DIV2_6')} />
+              <DroppableFileInput onChange={this.onValueChange} inputFileData={this.state.value} id={`${this.props.id}-value`} label={t('SINGLE:MSG_SECRETS_CREATEKEYVALUESECRET_DIV2_4')} inputFieldHelpText={t('SINGLE:MSG_SECRETS_CREATEKEYVALUESECRET_DIV2_6')} />
             </div>
           </div>
         </div>
@@ -1088,6 +1094,9 @@ type BaseEditSecretState_ = {
   inProgress: boolean;
   type: SecretType;
   stringData: {
+    [key: string]: string;
+  };
+  originData: {
     [key: string]: string;
   };
   error?: any;


### PR DESCRIPTION
#### What: 콘솔 시크릿 정보 표시 관련 ui 재적용 및 수정시 다른 값이 영향받는 현상 수정

#### Why: IMS 290316 재요청이 들어왔습니다.

#### How:
생성 : 평문으로 입력하며, 평문 가이드 Text 삭제
상세 : [값 표시하기] 클릭 시, 인코딩된 형태로 제공
수정 : 기존에 입력돼있던 값 Field는 공란으로 제공, 평문 가이드 Text 삭제
![image](https://user-images.githubusercontent.com/82989054/204424058-33705e69-3299-4f76-97fb-377b9fd62d4b.png)
![image](https://user-images.githubusercontent.com/82989054/204424079-fcee2842-76eb-4ec9-93c0-af609c6c588a.png)
![image](https://user-images.githubusercontent.com/82989054/204424095-844cf8a6-525c-42e2-ad25-ffcb1429cf3f.png)
+추가) 이때 수정부분에서 키값이 여러개일때 하나의 값만 수정해도 다른 값에 영향 받는 경우가 발생이 되어서 영향 받지 않도록 수정했습니다.

