### PR TITLE
[feat][patch] IMS 290755 검색 메뉴에 생성 기간 별 조회 기능 시작 날짜 수정

### DIFF
--- a/frontend/public/components/hypercloud/search.tsx
+++ b/frontend/public/components/hypercloud/search.tsx
@@ -48,7 +48,7 @@ const SearchPage_: React.FC<SearchProps & StateProps & DispatchProps> = props =>
   const [labelFilter, setLabelFilter] = React.useState([]);
   const [labelFilterInput, setLabelFilterInput] = React.useState('');
   const [typeaheadNameFilter, setTypeaheadNameFilter] = React.useState('');
-  const [startDate, setStartDate] = React.useState(new Date(0));
+  const [startDate, setStartDate] = React.useState(new Date(new Date().setFullYear(new Date().getFullYear() - 1)));
   const [endDate, setEndDate] = React.useState(new Date());
   const { namespace, noProjectsAvailable } = props;
 


### PR DESCRIPTION
#### What:IMS 290755 검색 메뉴에 생성 기간 별 조회 기능 시작 날짜를 작년으로 수정하였습니다.

<img width="1265" alt="스크린샷 2022-11-30 오전 11 20 54" src="https://user-images.githubusercontent.com/82989054/204692273-20844680-82c5-4889-bc8b-dd563c654cb1.png">

#### Why:ims요청입니다.

#### How: 시작 날 불러오는 코드 현재시각 기준 작년으로 불러왔습니다. 