### PR TITLE
[feat][patch][IMS 294550] 싱글클러스터 콘솔 잔여 이슈 수정

### DIFF
--- a/frontend/public/components/namespace-overview.tsx
+++ b/frontend/public/components/namespace-overview.tsx
@@ -8,8 +8,10 @@ import StatusCard from './namespace-overview-cards/status-card';
 import { UtilizationCard } from './namespace-overview-cards/utilization-card';
 import ActivityCard from './namespace-overview-cards/activity-card';
 import ResourceQuotaCard from './namespace-overview-cards/resource-quota-card';
+import { isSingleClusterPerspective } from '@console/internal/hypercloud/perspectives';
 
 const NamespaceOverview = props => {
+  const isSingle = isSingleClusterPerspective();
   const statusCard = {
     Card: StatusCard,
     props: {
@@ -63,7 +65,7 @@ const NamespaceOverview = props => {
   };
   const mainCards = [statusCard, utilizationCard, resourceQuotaCard];
   const leftCards = [detailCard, inventoryCard];
-  const rightCards = [claimCard, activityCard];
+  const rightCards = isSingle ? [activityCard] : [claimCard, activityCard];
   return (
     <Dashboard>
       <DashboardGrid mainCards={mainCards} leftCards={leftCards} rightCards={rightCards} />

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -42,13 +42,13 @@ const getDisplayName = obj => _.get(obj, ['metadata', 'annotations', 'openshift.
 const CREATE_NEW_RESOURCE = '#CREATE_RESOURCE_ACTION#';
 
 export const deleteModal = (kind, ns) => {
-  const {t} = useTranslation()
+  const { t } = useTranslation();
   let { label, weight, accessReview } = Kebab.factory.Delete(kind, ns);
   let callback = undefined;
   let tooltip;
- 
+
   if (ns.metadata.name === 'default') {
-    tooltip = `${t('COMMON:MSG_MAIN_TOOTIP_1', {0:kind.label})}`;
+    tooltip = `${t('COMMON:MSG_MAIN_TOOTIP_1', { 0: kind.label })}`;
   } else if (ns.status.phase === 'Terminating') {
     tooltip = `${kind.label} is already terminating`;
   } else {
@@ -188,15 +188,15 @@ export const NamespacesPage = props => {
   const pages = isSingleClusterPerspective()
     ? null
     : [
-      {
-        href: 'namespaces',
-        name: 'SINGLE:MSG_NAMESPACES_MAIN_TABNAMESPACES_1',
-      },
-      {
-        href: 'namespaceclaims?rowFilter-namespace-claim-status=Awaiting',
-        name: 'SINGLE:MSG_NAMESPACES_MAIN_TABNAMESPACECLAIMS_1',
-      },
-    ];
+        {
+          href: 'namespaces',
+          name: 'SINGLE:MSG_NAMESPACES_MAIN_TABNAMESPACES_1',
+        },
+        {
+          href: 'namespaceclaims?rowFilter-namespace-claim-status=Awaiting',
+          name: 'SINGLE:MSG_NAMESPACES_MAIN_TABNAMESPACECLAIMS_1',
+        },
+      ];
 
   return (
     <ListPage
@@ -204,8 +204,8 @@ export const NamespacesPage = props => {
       tableProps={namespacesTableProps}
       canCreate={true}
       multiNavPages={pages}
-    // createProps={createProps}
-    // createHandler={() => createNamespaceModal({ blocking: true })}
+      // createProps={createProps}
+      // createHandler={() => createNamespaceModal({ blocking: true })}
     />
   );
 };
@@ -251,19 +251,19 @@ const projectTableHeader = ({ showMetrics, showActions }) => {
     },
     ...(showMetrics
       ? [
-        {
-          title: 'Memory',
-          sortFunc: 'namespaceMemory',
-          transforms: [sortable],
-          props: { className: projectColumnClasses[4] },
-        },
-        {
-          title: 'CPU',
-          sortFunc: 'namespaceCPU',
-          transforms: [sortable],
-          props: { className: projectColumnClasses[5] },
-        },
-      ]
+          {
+            title: 'Memory',
+            sortFunc: 'namespaceMemory',
+            transforms: [sortable],
+            props: { className: projectColumnClasses[4] },
+          },
+          {
+            title: 'CPU',
+            sortFunc: 'namespaceCPU',
+            transforms: [sortable],
+            props: { className: projectColumnClasses[5] },
+          },
+        ]
       : []),
     {
       title: 'Created',
@@ -576,17 +576,17 @@ class NamespaceBarDropdowns_ extends React.Component {
       .forEach(name => (items[name] = name));
 
     const sortFuntion = (items, index) => {
-      let sortedItems = []
+      let sortedItems = [];
       items.forEach(([key, value], index) => {
         if (key === ALL_NAMESPACES_KEY) {
-          sortedItems.unshift([key, value])
+          sortedItems.unshift([key, value]);
         } else {
-          sortedItems.push([key, value])
+          sortedItems.push([key, value]);
         }
-      })
+      });
 
       return sortedItems;
-    }
+    };
 
     let title = activeNamespace;
     if (activeNamespace === ALL_NAMESPACES_KEY) {
@@ -599,11 +599,11 @@ class NamespaceBarDropdowns_ extends React.Component {
     }
     const defaultActionItem = canCreateProject
       ? [
-        {
-          actionTitle: `Create ${model.label}`,
-          actionKey: CREATE_NEW_RESOURCE,
-        },
-      ]
+          {
+            actionTitle: `Create ${model.label}`,
+            actionKey: CREATE_NEW_RESOURCE,
+          },
+        ]
       : [];
 
     const onChange = newNamespace => {
@@ -690,7 +690,7 @@ export const NamespacesDetailsPage = props => (
       },
       navFactory.editResource(),
       navFactory.roles(RolesPage),
-      navFactory.metering(),
+      !isSingleClusterPerspective() && navFactory.metering(),
     ]}
   />
 );


### PR DESCRIPTION
What:[IMS 294550] 싱글클러스터 콘솔 잔여 이슈 수정 하였습니다.
<img width="1288" alt="스크린샷 2022-12-01 오전 9 45 37" src="https://user-images.githubusercontent.com/82989054/204939456-45bc8c27-e005-4eb3-8ff1-953e340ad89a.png">
<img width="1297" alt="스크린샷 2022-12-01 오전 9 44 57" src="https://user-images.githubusercontent.com/82989054/204939469-23d03c02-05e2-4b69-8a05-5334d97495a8.png">

Why: 회의 에서 정해진 내용을 토대로 2번 3번 오류를 수정했습니다.
How:
홈 > 네임스페이스
네임스페이스 상세에서 클레임 판넬 이슈

클러스터 템플릿 클레임, 롤바인딩 클레임 링크 각각 클릭시 "404 Not Found" 발생 수정

클레임 판넬 싱글 클러스터에서 삭제
홈 > 네임스페이스
네임스페이스 상세에서 미터링 탭 화면 이슈

싱글 클러스터에서 미터링탭 삭제