### PR TITLE
[bugfix][patch][IMS 290756] [5.0] [천주교] 파드 탭에서 필터 다중 선택 기능 (이슈분리: 290664) - event page 다중 선택시 창 유지

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -178,7 +178,7 @@ class _EventsList extends React.Component {
       <>
         <PageHeading detail={true} title={this.props.title}>
           <div className="co-search-group">
-            <ResourceListDropdown onChange={this.toggleSelected} selected={Array.from(selected)} showAll clearSelection={this.clearSelection} className="co-search-group__resource" />
+            <ResourceListDropdown onChange={this.toggleSelected} selected={Array.from(selected)} showAll clearSelection={this.clearSelection} className="co-search-group__resource" type='multiple' />
             <Dropdown className="btn-group co-search-group__resource" items={eventTypes} onChange={v => this.setState({ type: v })} selectedKey={type} title={selectedType} />
             <TextFilter autoFocus={autoFocus} label={t('SINGLE:MSG_EVENTS_MAIN_PLACEHOLDER_1')} onChange={val => this.setState({ textFilter: val || '' })} />
             {!isSingleClusterPerspective() && (


### PR DESCRIPTION
ResourceListDropdown 의 type을 multiple 로 추가하여 여러개 선택시 선택마다 창이 닫히는 과정 없이 연속해서 선택 가능하게 함

![image](https://user-images.githubusercontent.com/48277126/205202123-c0d59853-209a-4f91-8fcc-839781f7d82c.png)
