### PR TITLE
[bugfix][patch] 개요 페이지 버전 상세 표시 부분 오타 수정

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
@@ -21,7 +21,7 @@ const ModuleStatus = ({ status }) => {
   switch (status) {
     case 'Normal':
       return <GreenCheckCircleIcon />;
-    case 'Abnoraml':
+    case 'Abnormal':
       return <RedExclamationCircleIcon />;
     default:
       return <div></div>;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48277126/205578824-75a2ea93-4475-4a92-b44f-fe344e7857d1.png)
Version api 에서 Abnormal 정상적으로 보내고 있었으나 코드 오타로 인하여 정상적으로 icon 나오지 않음