### PR TITLE
[feat][patch][IMS 290756] taskRef 없는 task 포함된 pipeline 수정시 taskRef 사용부분 예외처리, pipeline run 에서 workspace 에 type 없는 pipeline 선택시 예외처리

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/hooks.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/hooks.ts
@@ -189,8 +189,8 @@ export const useNodes = (
       },
     });
 
-  const invalidTaskList = taskGroup.tasks.filter((task) => !getTask(task.taskRef));
-  const validTaskList = taskGroup.tasks.filter((task) => !!getTask(task.taskRef));
+  const invalidTaskList = taskGroup.tasks.filter((task) => task.taskRef && !getTask(task.taskRef));
+  const validTaskList = taskGroup.tasks.filter((task) => task.taskRef && !!getTask(task.taskRef));
 
   const invalidTaskListNodes: PipelineTaskListNodeModel[] = invalidTaskList.map((task) =>
     newInvalidListNode(task.name, task.runAfter),
@@ -200,7 +200,7 @@ export const useNodes = (
       ? tasksToBuilderNodes(
           validTaskList,
           onNewListNode,
-          (task) => onTaskSelection(task, getTask(task.taskRef)),
+          (task) => task.taskRef && onTaskSelection(task, getTask(task.taskRef)),
           getErrorMessage(nodeTaskErrors, tasksInError),
           taskGroup.highlightedIds,
         )

--- a/frontend/public/components/hypercloud/form/pipelineruns/sync-form-data.ts
+++ b/frontend/public/components/hypercloud/form/pipelineruns/sync-form-data.ts
@@ -63,7 +63,7 @@ export const convertToForm = (data: any) => {
   _.forEach(_data.spec?.workspaces, workspace => {
     let _name = workspace.name;
 
-    let type = 'emptyDir' in workspace ? 'EmptyDirectory' : 'VolumeClaimTemplate';
+    let type = 'emptyDir' in workspace ? 'EmptyDirectory' : 'volumeClaimTemplate' in workspace ? 'VolumeClaimTemplate' : '';
     if (type === 'VolumeClaimTemplate') {
       workspace.volumeClaimTemplate.spec.accessModes = workspace.volumeClaimTemplate.spec.accessModes[0];
     }


### PR DESCRIPTION
taskRef 없는 task 포함된 pipeline 수정시 taskRef 사용부분 예외처리
원인: 파이프라인 수정 과정에서 getTask 함수에 taskRef를 사용하는 부분이 있음
해결: taskRef 없으면 taskRef 사용하는 함수 사용 안하게 예외처리함

pipeline run 에서 workspace 에 type 없는 pipeline 선택시 예외처리
원인: workspace type이 emptyDir 이 아니면 무조건 VolumeClaimTemplate 이 되어서 생기는 문제
해결: volumeClaimTemplate key 가 있으면 VolumeClaimTemplate type으로 설정함(관련 key 없으면 빈 string 으로 넣어줌)
(pipelinerun 생성에서 다른 타입이 있어어 관련사항은 IMS에 문의하여 추후 진행할 계획)