### PR TITLE
[feat][patch][IMS 295182] 싱글 클러스터 검색 리스트 수정

### DIFF
--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -127,7 +127,6 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = props => {
     isSingleClusterPerspective() && inSingle();
   }, []);
 
-  // isSingleClusterPerspective() && inSingle();
   const resources = models
     .filter(({ apiGroup, apiVersion, kind, verbs }) => {
       // Remove blacklisted items.

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -9,7 +9,7 @@ import { Dropdown, ResourceIcon } from './utils';
 import { apiVersionForReference, K8sKind, K8sResourceKindReference, K8sVerb, kindToAbbr, modelFor, pluralizeKind, referenceForModel } from '../module/k8s';
 import { Badge, Checkbox } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { getSingleClusterFullBasePath } from '@console/internal/hypercloud/perspectives';
+// import { getSingleClusterFullBasePath } from '@console/internal/hypercloud/perspectives';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { isSingleClusterPerspective } from '@console/internal/hypercloud/perspectives';
 // Blacklist known duplicate resources.
@@ -67,11 +67,11 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = props => {
   const [models, setModels] = React.useState(allModels);
   const [versions, setVersions] = React.useState(preferredVersions);
   async function inSingle() {
-    await coFetchJSON(`${getSingleClusterFullBasePath()}/api/kubernetes/apis`).then(res => {
+    await coFetchJSON(`/api/kubernetes/apis`).then(res => {
       const preferredVersions = res.groups.map(group => group.preferredVersion);
       const all: Promise<APIResourceList>[] = _.flatten(res.groups.map(group => group.versions.map(version => `/apis/${version.groupVersion}`)))
         .concat(['/api/v1'])
-        .map(p => coFetchJSON(`${getSingleClusterFullBasePath()}/api/kubernetes${p}`).catch(err => err));
+        .map(p => coFetchJSON(`/api/kubernetes${p}`).catch(err => err));
       return Promise.all(all).then(data => {
         const resourceSet = new Set<string>();
         const namespacedSet = new Set<string>();

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -9,7 +9,6 @@ import { Dropdown, ResourceIcon } from './utils';
 import { apiVersionForReference, K8sKind, K8sResourceKindReference, K8sVerb, kindToAbbr, modelFor, pluralizeKind, referenceForModel } from '../module/k8s';
 import { Badge, Checkbox } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-// import { getSingleClusterFullBasePath } from '@console/internal/hypercloud/perspectives';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { isSingleClusterPerspective } from '@console/internal/hypercloud/perspectives';
 // Blacklist known duplicate resources.

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -64,7 +64,7 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = props => {
   const { selected, onChange, allModels, showAll, className, preferredVersions, type } = props;
   const { t } = useTranslation();
   const [models, setModels] = React.useState(allModels);
-  const [versions, setVersions] = React.useState(preferredVersions);
+  const [preferredVersionsState, setPreferredVersionsState] = React.useState(preferredVersions);
   async function inSingle() {
     await coFetchJSON(`/api/kubernetes/apis`).then(res => {
       const preferredVersions = res.groups.map(group => group.preferredVersion);
@@ -112,13 +112,13 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = props => {
             });
         };
         allResources.forEach(r => (ADMIN_RESOURCES.has(r.split('/')[0]) ? adminResources.push(r) : safeResources.push(r)));
-        const modelss = _.flatten(data.filter(d => d.resources).map(defineModels));
+        const singleModels = _.flatten(data.filter(d => d.resources).map(defineModels));
         let obj = {};
-        modelss.forEach(element => {
+        singleModels.forEach(element => {
           obj[element.apiGroup + '~' + element.apiVersion + '~' + element.kind] = element;
         });
         setModels(ImmutableMap(obj));
-        setVersions(preferredVersions);
+        setPreferredVersionsState(preferredVersions);
       });
     });
   }
@@ -138,7 +138,7 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = props => {
         return false;
       }
       // Only show preferred version for resources in the same API group.
-      const preferred = (m: K8sKind) => versions.some(v => v.groupVersion === apiVersionForReference(referenceForModel(m)));
+      const preferred = (m: K8sKind) => preferredVersionsState.some(v => v.groupVersion === apiVersionForReference(referenceForModel(m)));
       const sameGroupKind = (m: K8sKind) => m.kind === kind && m.apiGroup === apiGroup && m.apiVersion !== apiVersion;
 
       return !models.find(m => sameGroupKind(m) && preferred(m));


### PR DESCRIPTION
what: 싱글 클러스터 검색페이지의 리스트가 
전체 리소스를(마스터 리소스) 띄워주던 것을 
싱글클러스터 리소스만 띄워지게 수정했습니다.
<img width="798" alt="스크린샷 2022-12-13 오후 2 50 18" src="https://user-images.githubusercontent.com/82989054/207238764-f1e54fcb-f032-463d-8157-f2f37d5295ec.png">
<img width="584" alt="스크린샷 2022-12-13 오후 2 48 42" src="https://user-images.githubusercontent.com/82989054/207238792-41e8c376-4272-4f2c-922d-2c44fbadb920.png">

why: 검색 페이지는 싱글 클러스터이던지 마스터 클러스터 이던지 구분하지않고 페이지를 뛰워주는 페이지였습니다. 때문에 전체 리소스를 가공한 함수에서 리덕스를 이용하여 그냥 가져와서 리소스 리스트를 구성하는 방식으로 구동이 되고 있었습니다.
how: 싱글 클러스터의 리소스를 받아온 다음 드롭다운에 맞는 형식으로 가공한다음 랜더링 하도록 하였습니다. 
