### PR TITLE
[feat][patch][IMS 291634] k8s 네이밍 규칙에 맞는 pod 생성을 위한 유저 아이디 수정

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/hypercloud/HyperCloudShellTerminal.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/hypercloud/HyperCloudShellTerminal.tsx
@@ -26,9 +26,9 @@ const HyperCloudShellTerminal: React.FC<CloudShellTerminalProps> = ({ user }) =>
   const [kubectlPodReady, setKubectlPodReady] = React.useState(false);
   const [time, setTime] = React.useState(new Date());
   const { t } = useTranslation();
+
   // API call
   React.useEffect(() => {
-    coFetchJSON(`api/hypercloud/kubectl?userName=${user['email']}`, 'POST');
     coFetchJSON(`api/hypercloud/kubectl?userName=${user['email']}`, 'GET')
       .then(response => {
         let date = new Date();
@@ -42,7 +42,7 @@ const HyperCloudShellTerminal: React.FC<CloudShellTerminalProps> = ({ user }) =>
 
   React.useEffect(() => {
     const podCheck = setInterval(() => {
-      k8sGet(PodModel, `${namespace}-${user['email'].replace('@', '.')}`, namespace).then(data => {
+      k8sGet(PodModel, `${namespace}-${user['email'].replace(/_/g, '-').replace('@', '.')}`, namespace).then(data => {
         setKubectlPod(data);
         if (data.status.phase === 'Running') {
           setKubectlPodReady(true);

--- a/frontend/packages/console-app/src/components/cloud-shell/hypercloud/HyperCloudShellTerminal.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/hypercloud/HyperCloudShellTerminal.tsx
@@ -29,6 +29,7 @@ const HyperCloudShellTerminal: React.FC<CloudShellTerminalProps> = ({ user }) =>
 
   // API call
   React.useEffect(() => {
+    coFetchJSON(`api/hypercloud/kubectl?userName=${user['email']}`, 'POST');
     coFetchJSON(`api/hypercloud/kubectl?userName=${user['email']}`, 'GET')
       .then(response => {
         let date = new Date();


### PR DESCRIPTION
what: 터미널 pod 생성을 위한 유저 아이디 수정
why: k8s 네이밍 규칙에 맞는 pod를 생성해야하기 때문에 아이디에 _ 를 - 로 수정을 한것에 맞추어 데이터를 받아오는 유저 아이디에서 "_" 를 "-" 로 수정하였습니다.
<img width="861" alt="스크린샷 2022-12-14 오후 4 07 28" src="https://user-images.githubusercontent.com/82989054/207530506-c3850b7a-e3e1-4976-b848-03747d1bf828.png">
<img width="1003" alt="스크린샷 2022-12-14 오후 4 17 13" src="https://user-images.githubusercontent.com/82989054/207530517-0e6cf860-f9a5-4d99-b0b5-25fccb212c6a.png">
