### PR TITLE
[feat][patch][ims291634] kubectl 커맨창 남은 시간 수정,  kubect 커맨창 종료시 팝업 제거

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/cloudShellConfirmationModal.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/cloudShellConfirmationModal.ts
@@ -1,10 +1,9 @@
 import { confirmModal } from '@console/internal/components/modals/confirm-modal';
 
-const cloudShellConfirmationModal = (action) => {
+const cloudShellConfirmationModal = action => {
   return confirmModal({
     title: 'Close Terminal?',
-    message:
-      'This will close the terminal session. Content in the terminal will not be restored on next session.',
+    message: 'This will close the terminal session. Content in the terminal will not be restored on next session.',
     btnText: 'Yes',
     submitDanger: true,
     cancelText: 'No',

--- a/frontend/packages/console-app/src/components/cloud-shell/hypercloud/HyperCloudShellTerminal.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/hypercloud/HyperCloudShellTerminal.tsx
@@ -57,7 +57,7 @@ const HyperCloudShellTerminal: React.FC<CloudShellTerminalProps> = ({ user }) =>
     <div>
       <div className="co-cloud-shell-drawer__heading">
         {t('COMMON:MSG_MAIN_POPUP_DESCRIPTION_30', {
-          0: time.getFullYear() + '.' + time.getMonth() + '.' + time.getDay() + ' ' + time.getHours() + ':' + time.getMinutes(),
+          0: time.getFullYear() + '.' + (Number(time.getMonth()) + 1) + '.' + time.getDate() + ' ' + time.getHours() + ':' + time.getMinutes(),
         })}
       </div>
       <PodExecLoader obj={kubectlPod} />

--- a/frontend/public/components/modals/confirm-modal.jsx
+++ b/frontend/public/components/modals/confirm-modal.jsx
@@ -9,6 +9,11 @@ class ConfirmModal extends PromiseComponent {
     super(props);
     this._submit = this._submit.bind(this);
     this._cancel = this.props.cancel.bind(this);
+    this.handlePromise(
+      this.props.executeFn(null, {
+        supressNotifications: true,
+      }),
+    ).then(this.props.close);
   }
 
   _submit(event) {
@@ -20,20 +25,12 @@ class ConfirmModal extends PromiseComponent {
       }),
     ).then(this.props.close);
   }
-
   render() {
     return (
       <form onSubmit={this._submit} name="form" className="modal-content">
         <ModalTitle>{this.props.title}</ModalTitle>
         <ModalBody>{this.props.message}</ModalBody>
-        <ModalSubmitFooter
-          errorMessage={this.state.errorMessage}
-          inProgress={this.state.inProgress}
-          submitText={this.props.btnText || 'Confirm'}
-          cancel={this._cancel}
-          cancelText={this.props.cancelText || 'Cancel'}
-          submitDanger={this.props.submitDanger}
-        />
+        <ModalSubmitFooter errorMessage={this.state.errorMessage} inProgress={this.state.inProgress} submitText={this.props.btnText || 'Confirm'} cancel={this._cancel} cancelText={this.props.cancelText || 'Cancel'} submitDanger={this.props.submitDanger} />
       </form>
     );
   }


### PR DESCRIPTION
what: kubectl 커맨창 남은 시간 수정 하였고,  kubect 커맨창 종료시 팝업 제거 하였습니다.
why: getMonth()는 1월이 0부터 시작을 하기때문에 1을 더해주어야 되어서 이를 추가하였습니다. getDate 함수를 사용해야 했던것을 getDay 함수를 사용하여 문제가 발생하여서 이를 수정하였습니다. 이전에 터미널을 닫을때 안내 메세지를 팝업으로 띄워주는 부분이 있었는데 기획상 필요없다는 요청이 들어와서 팝업을 삭제하였습니다.