### PR TITLE
[feat] 파이프 라인 승인 페이지 상태 필터문구 수정

### DIFF
--- a/frontend/public/components/hypercloud/pipeline-approval.tsx
+++ b/frontend/public/components/hypercloud/pipeline-approval.tsx
@@ -148,7 +148,7 @@ const filters = t => [
     reducer: pipelineApprovalStatusReducer,
     items: [
       { id: 'Approved', title: 'Approved' },
-      { id: 'Waiting', title: 'Waiting' },
+      { id: 'Awaiting', title: 'Awaiting' },
       { id: 'Rejected', title: 'Rejected' },
     ],
   },


### PR DESCRIPTION
what: 파이프 라인 승인 페이지 상태 필터문구 수정하였습니다.
<img width="608" alt="image" src="https://user-images.githubusercontent.com/82989054/210023118-b2d87255-805e-4550-8874-30d30d7eabc8.png">
why:필터문구 기준이 waiting 으로 되어있어서 필터가 안되는 현상이 발생해서 상태와 맞는 필터 문구를 
waiting 에서 Awaiting으로 바꾸어 필터가 정상 작동하도록 하였습니다.
