### PR TITLE
[feat][patch] GNB 4a, 4b, 계정관리 항목 아이콘 추가

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellMastheadButton.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellMastheadButton.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
 import { RootState } from '@console/internal/redux';
-import { TerminalIcon } from '@patternfly/react-icons';
 import { isCloudShellExpanded } from '../../redux/reducers/cloud-shell-reducer';
 import { Button, ToolbarItem, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { connectToFlags, WithFlagsProps } from '@console/internal/reducers/features';
@@ -14,7 +13,6 @@ import { checkTerminalAvailable } from './cloud-shell-utils';
 type DispatchProps = {
   onClick: () => void;
 };
-
 type StateProps = {
   open?: boolean;
 };
@@ -62,7 +60,7 @@ const ClouldShellMastheadButton: React.FC<Props> = ({ flags, onClick, open }) =>
     <ToolbarItem>
       <Tooltip content={open ? 'Close command line terminal' : 'Open command line terminal'} position={TooltipPosition.bottom}>
         <Button variant="plain" aria-label="Command line terminal" onClick={toggleTerminal} className={open ? 'pf-m-selected' : undefined}>
-          <TerminalIcon className="co-masthead-icon" />
+          <div className="pf-c-app-launcher__menu-item">kubectl Command Line</div>
         </Button>
       </Tooltip>
     </ToolbarItem>

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -18,12 +18,53 @@ import { clusterVersionReference, getReportBugLink } from '../module/k8s/cluster
 import * as redhatLogoImg from '../imgs/logos/redhat.svg';
 import { ExpTimer } from './hypercloud/exp-timer';
 import { createAccountUrl, logout as _logout, tokenRefresh } from '../hypercloud/auth';
-import { withTranslation } from 'react-i18next';
+import { useTranslation, withTranslation } from 'react-i18next';
 import i18n from 'i18next';
 import { HyperCloudManualLink } from './utils';
 import { setLanguage } from './hypercloud/utils/langs/i18n';
 import { hideChatbot } from './hypercloud/chatbot/chatbot';
+import { Dropdown, DropdownToggle, DropdownGroup, DropdownItem } from '@patternfly/react-core';
 
+import React from 'react';
+import { Dropdown, DropdownToggle, DropdownGroup, DropdownItem } from '@patternfly/react-core';
+
+export const DropdownGroups = () => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const { t } = useTranslation();
+
+  const onToggle = isOpen => {
+    setIsOpen(isOpen);
+  };
+
+  const onFocus = () => {
+    const element = document.getElementById('toggle-groups');
+    element.focus();
+  };
+
+  const onSelect = () => {
+    setIsOpen(false);
+    onFocus();
+  };
+
+  const dropdownItems = [
+    <DropdownGroup key="group 1">
+      <DropdownItem key="group 1 link">
+        <a href={HyperCloudManualLink} target="_blank" className="pf-c-app-launcher__menu-item">
+          {t('COMMON:MSG_GNB_MORE_1')}
+        </a>
+      </DropdownItem>
+      <DropdownItem key="group 1 action" component="button">
+        <CloudShellMastheadButton />
+      </DropdownItem>
+    </DropdownGroup>,
+  ];
+  const helpToggle = (
+    <span className="pf-c-dropdown__toggle">
+      <QuestionCircleIcon color="white" />
+    </span>
+  );
+  return <ApplicationLauncher aria-label="User menu" data-test="user-dropdown" className="co-app-launcher" onSelect={onSelect} onToggle={onToggle} isOpen={isOpen} items={dropdownItems} toggleIcon={helpToggle} color="white" isGrouped />;
+};
 const SystemStatusButton = ({ statuspageData, className }) =>
   !_.isEmpty(_.get(statuspageData, 'incidents')) ? (
     <ToolbarItem className={className}>
@@ -352,7 +393,7 @@ class MastheadToolbarContents_ extends React.Component {
       //   ],
       // });
 
-      return <ApplicationLauncher aria-label="Utility menu" className="co-app-launcher" onSelect={this._onKebabDropdownSelect} onToggle={this._onKebabDropdownToggle} isOpen={isKebabDropdownOpen} items={this._renderApplicationItems(actions)} position="right" toggleIcon={<EllipsisVIcon color="white" />} isGrouped />;
+      return <ApplicationLauncher aria-label="Utility menu" className="co-app-launcher" onSelect={this._onKebabDropdownSelect} onToggle={this._onKebabDropdownToggle} isOpen={isKebabDropdownOpen} items={this._renderApplicationItems(actions)} toggleIcon={<EllipsisVIcon color="white" />} isGrouped />;
     }
 
     if (_.isEmpty(actions)) {
@@ -366,7 +407,6 @@ class MastheadToolbarContents_ extends React.Component {
         <AngleDownIcon className="pf-c-dropdown__toggle-icon" color="#757575" />
       </span>
     );
-
     return <ApplicationLauncher aria-label="User menu" data-test="user-dropdown" className="co-app-launcher co-user-menu" onSelect={this._onUserDropdownSelect} onToggle={this._onUserDropdownToggle} isOpen={isUserDropdownOpen} items={this._renderApplicationItems(actions)} position="right" toggleIcon={userToggle} isGrouped />;
   }
   _renderLanguageMenu(mobile) {
@@ -493,14 +533,7 @@ class MastheadToolbarContents_ extends React.Component {
                 </Link>
               </Tooltip>
             </ToolbarItem>
-            <CloudShellMastheadButton />
-            <ToolbarItem className="co-masthead-icon__button">
-              <Tooltip content="Manual" position={TooltipPosition.bottom}>
-                <a href={HyperCloudManualLink} target="_blank">
-                  <QuestionCircleIcon className="co-masthead-icon" color="white" />
-                </a>
-              </Tooltip>
-            </ToolbarItem>
+            <DropdownGroups />
           </ToolbarGroup>
 
           <ToolbarGroup>

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -393,7 +393,7 @@ class MastheadToolbarContents_ extends React.Component {
       //   ],
       // });
 
-      return <ApplicationLauncher aria-label="Utility menu" className="co-app-launcher" onSelect={this._onKebabDropdownSelect} onToggle={this._onKebabDropdownToggle} isOpen={isKebabDropdownOpen} items={this._renderApplicationItems(actions)} toggleIcon={<EllipsisVIcon color="white" />} isGrouped />;
+      return <ApplicationLauncher aria-label="Utility menu" className="co-app-launcher" onSelect={this._onKebabDropdownSelect} onToggle={this._onKebabDropdownToggle} isOpen={isKebabDropdownOpen} items={this._renderApplicationItems(actions)} position="right" toggleIcon={<EllipsisVIcon color="white" />} isGrouped />;
     }
 
     if (_.isEmpty(actions)) {


### PR DESCRIPTION
what:기획문서를 기준으로 이전에 분리되었던 아이콘 2개를 드랍 다운으로 합쳤습니다.
<img width="1728" alt="스크린샷 2023-01-03 오전 10 16 52" src="https://user-images.githubusercontent.com/82989054/210292033-6347bb4f-e9be-4577-aac2-4ed4ec1858cd.png">
how: help아이콘을 누르면 터미널창과 이전 메뉴얼창을 들어갈수 있도록 토글을 만들었습니다.
<img width="1640" alt="스크린샷 2023-01-03 오전 10 51 01" src="https://user-images.githubusercontent.com/82989054/210292120-0aa0a520-ae25-483c-abd6-606cef773203.png">
