### PR TITLE
[feat][patch] crd에 정의 되지 않고 스키마가 없는 리소스의 경우 상세 - 수정 페이지 삭제

### DIFF
--- a/frontend/public/components/default-resource.jsx
+++ b/frontend/public/components/default-resource.jsx
@@ -6,10 +6,12 @@ import { Conditions } from './conditions';
 import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
 import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
-import { referenceFor, kindForReference, modelFor } from '../module/k8s';
+import { referenceFor, kindForReference, modelFor, k8sList } from '../module/k8s';
 import { Kebab, kindObj, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading, Timestamp } from './utils';
 import { ResourceLabel } from '../models/hypercloud/resource-plural';
 import { useTranslation } from 'react-i18next';
+import { isResourceSchemaBasedMenu } from './hypercloud/form';
+import { CustomResourceDefinitionModel } from '../models';
 
 const { common } = Kebab.factory;
 
@@ -94,16 +96,26 @@ export const DefaultList = props => {
 DefaultList.displayName = 'DefaultList';
 
 export const DefaultPage = props => {
-  const exceptionKindList = ['ClusterRole'];  
+  const exceptionKindList = ['ClusterRole'];
   const canCreate = exceptionKindList.includes(props.kind) ? false : props.canCreate || _.get(modelFor(props.kind), 'crd') !== 'false';
   return <ListPage {...props} ListComponent={DefaultList} canCreate={canCreate} />;
 };
 DefaultPage.displayName = 'DefaultPage';
 
 export const DefaultDetailsPage = props => {
-  const pages = [navFactory.details(DetailsForKind(props.kind)), navFactory.editResource()];
   const menuActions = [...Kebab.getExtensionsActionsForKind(kindObj(props.kind)), ...common];
+  const [pageState, setPageState] = React.useState([navFactory.details(DetailsForKind(props.kind)), navFactory.editResource()]);
+  const isCustomResourceType = !isResourceSchemaBasedMenu(props.kind);
 
-  return <DetailsPage {...props} menuActions={menuActions} pages={pages} />;
+  React.useEffect(() => {
+    isCustomResourceType &&
+      k8sList(CustomResourceDefinitionModel).then(res => {
+        _.find(res, function(data) {
+          return data.spec.names.kind === props.kind;
+        }) || setPageState([navFactory.details(DetailsForKind(props.kind))]);
+      });
+  }, []);
+
+  return <DetailsPage {...props} menuActions={menuActions} pages={pageState} />;
 };
 DefaultDetailsPage.displayName = 'DefaultDetailsPage';

--- a/frontend/public/components/default-resource.jsx
+++ b/frontend/public/components/default-resource.jsx
@@ -105,13 +105,12 @@ DefaultPage.displayName = 'DefaultPage';
 export const DefaultDetailsPage = props => {
   const menuActions = [...Kebab.getExtensionsActionsForKind(kindObj(props.kind)), ...common];
   const [pageState, setPageState] = React.useState([navFactory.details(DetailsForKind(props.kind)), navFactory.editResource()]);
-  const isCustomResourceType = !isResourceSchemaBasedMenu(props.kind);
-
+  const isCustomResourceType = !isResourceSchemaBasedMenu(props.kindObj.kind);
   React.useEffect(() => {
     isCustomResourceType &&
       k8sList(CustomResourceDefinitionModel).then(res => {
         _.find(res, function(data) {
-          return data.spec.names.kind === props.kind;
+          return data.spec.names.kind === props.kindObj.kind;
         }) || setPageState([navFactory.details(DetailsForKind(props.kind))]);
       });
   }, []);


### PR DESCRIPTION
what: crd에 정의 되지 않고 스키마가 없는 리소스의 경우 상세 페이지의 수정탭을 삭제하였습니다.
why: 이전에 스키마도 없고 crd정의도 없는 경우 페이지를 따로 만들어 놓지도 않아서 수정페이지에 들어갈 시 무한 로딩이 되는 현상이 발생하였습니다. 
<img width="1160" alt="image" src="https://user-images.githubusercontent.com/82989054/210306938-eb44cdbf-4167-44a2-9297-3bb8c9bd6412.png">
