### PR TITLE
[feat] 롤 바인딩 렌더링 안되는 오류수정

### DIFF
--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -431,12 +431,12 @@ export const MultiListPage = props => {
     namespace: r.namespaced ? namespace : r.namespace,
     prop: r.prop || r.kind,
   }));
-  const isCustomResourceType = !isResourceSchemaBasedMenu(resources[0].kindObj.kind);
+  const isCustomResourceType = !isResourceSchemaBasedMenu(resources[0]?.kindObj?.kind);
   React.useEffect(() => {
     isCustomResourceType &&
       k8sList(CustomResourceDefinitionModel).then(res => {
         _.find(res, function(data) {
-          return data.spec.names.kind === resources[0].kindObj.kind;
+          return data.spec.names.kind === resources[0]?.kindObj?.kind;
         }) ||
           ((href = namespace ? `/k8s/ns/${namespace}/import` : `/k8s/all-namespaces/import`) && setCreatePropsState({ to: href }));
       });


### PR DESCRIPTION
<img width="1124" alt="image" src="https://user-images.githubusercontent.com/82989054/210496420-dbdd65db-5994-43b3-8ac3-b86ed34b21dc.png">
해당 프롭스가 없는 경우가 있어서 롤바인딩 페이지가 렌더링 안된던 버그를 수정했습니다.