### PR TITLE
[bugfix][patch][IMS 294948][IMS 294952] Redis kafka 국문화 - schema 연결 수정

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -183,7 +183,7 @@ export const EditYAML_ = connect(stateToProps)(
       const url = getResourceSchemaUrl(model, isCustomResourceType);
       url &&
         coFetchJSON(url).then(template => {
-          this.setState({ definition: isCustomResourceType ? template?.spec?.validation?.openAPIV3Schema : JSON.parse(template) });
+          this.setState({ definition: isCustomResourceType ? (template?.spec?.validation?.openAPIV3Schema ? template?.spec?.validation?.openAPIV3Schema : template?.spec?.versions[0]?.schema?.openAPIV3Schema) : JSON.parse(template) });
         });
     }
 


### PR DESCRIPTION
IMS 내용: sidebar 에 스키마 표시 안되던 문제
원인: spec.validation.openAPIV3Schema 에서만 schema 를 찾은 후 sidebar 에 나오게 하는 문제가 있었음
해결: spec.validation.openAPIV3Schema 가 없을때는 spec.versions[0].schema.openAPIV3Schema 에서 schema 를 확인하도록 수정함 

![image](https://user-images.githubusercontent.com/48277126/210508183-b3f6fe0b-8817-407c-860a-41f3d7841610.png)
