### PR TITLE
[feat][patch]서비스콜 보내는 데이터에 한글로 들어가는 오류 수정

### DIFF
--- a/frontend/public/components/hypercloud/modals/status-modal.jsx
+++ b/frontend/public/components/hypercloud/modals/status-modal.jsx
@@ -64,7 +64,7 @@ const BaseStatusModal = withTranslation()(
         case RoleBindingClaimModel.kind:
         case ResourceQuotaClaimModel.kind:
         case NamespaceClaimModel.kind: {
-          const stat = this.state.status === t('COMMON:MSG_COMMON_BUTTON_COMMIT_9') ? t('COMMON:MSG_COMMON_BUTTON_COMMIT_9') : t('COMMON:MSG_COMMON_BUTTON_COMMIT_10');
+          const stat = this.state.status === t('COMMON:MSG_COMMON_BUTTON_COMMIT_9') ? 'Approved' : 'Rejected';
           const promise = k8sUpdateApproval(
             kind,
             resource,
@@ -94,7 +94,7 @@ const BaseStatusModal = withTranslation()(
           break;
         }
         case ClusterTemplateClaimModel.kind: {
-          const stat = this.state.status === t('COMMON:MSG_COMMON_BUTTON_COMMIT_9') ? t('COMMON:MSG_COMMON_BUTTON_COMMIT_9') : t('COMMON:MSG_COMMON_BUTTON_COMMIT_10');
+          const stat = this.state.status === t('COMMON:MSG_COMMON_BUTTON_COMMIT_9') ? 'Approved' : 'Rejected';
           const promise = k8sUpdateApproval(
             kind,
             resource,


### PR DESCRIPTION
what:서비스콜 보내는 데이터에 한글로 들어가는 오류 수정
why: 승인 번역 하는 과정에서 api 콜을 한글로 보내는 과정이 있어서 이를 수정했습니다.
<img width="1301" alt="image" src="https://user-images.githubusercontent.com/82989054/210683590-e6ae2aa8-d3d2-469d-adbc-f0ca12d39f3c.png">
