### PR TITLE
[feat][patch]네임스페이스 변경시에 동기적으로 변하지 않는 props 동기적으로 변하수정 수정

### DIFF
--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -433,6 +433,9 @@ export const MultiListPage = props => {
   }));
   const isCustomResourceType = !isResourceSchemaBasedMenu(resources[0]?.kindObj?.kind);
   React.useEffect(() => {
+    setCreatePropsState(createProps);
+  }, [createProps]);
+  React.useEffect(() => {
     isCustomResourceType &&
       k8sList(CustomResourceDefinitionModel).then(res => {
         _.find(res, function(data) {


### PR DESCRIPTION
what:네임스페이스 변경시에 동기적으로 변하지 않는 props 동기적으로 변하수정 수정
why: 클러스터 -> 클러스터 클레임->모든 네임 스페이스일때 새로고침하고 네임스페이스를 선택하고 생성을 누르면 전 네임스페이스로 들어가는 현상이 발생하였습니다.
props로 전달이 되는 부분에 해당 내용이 useState 로 묶여있어서 Props가 변하는 것을 인지하지 못하는 것이 문제였습니다.
how:useEffect를 추가해서 강제로 인식하도록 바꾸었습니다