### PR TITLE
[bugfix] schema 의  properties 없는 경우 sidebar 에 schema 나오지 않게 수정

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -183,7 +183,9 @@ export const EditYAML_ = connect(stateToProps)(
       const url = getResourceSchemaUrl(model, isCustomResourceType);
       url &&
         coFetchJSON(url).then(template => {
-          this.setState({ definition: isCustomResourceType ? (template?.spec?.validation?.openAPIV3Schema ? template?.spec?.validation?.openAPIV3Schema : template?.spec?.versions[0]?.schema?.openAPIV3Schema) : JSON.parse(template) });
+          const currentDefinition = isCustomResourceType ? (template?.spec?.validation?.openAPIV3Schema ? template?.spec?.validation?.openAPIV3Schema : template?.spec?.versions[0]?.schema?.openAPIV3Schema) : JSON.parse(template);
+          const currentProperties = _.get(currentDefinition, 'properties') || _.get(currentDefinition, 'items.properties');
+          this.setState({ definition: currentProperties ? currentDefinition : null });
         });
     }
 


### PR DESCRIPTION
schema 에서 properties 가 없으면 sidebar 에서 property 없음 나오는 상황
explore-type-sidebar.tsx
`const currentProperties = _.get(currentDefinition, 'properties') || _.get(currentDefinition, 'items.properties');
...
{_.isEmpty(currentProperties) ? (
        <EmptyBox label="Properties" />
      ) : ( ...`

edit-yaml.jsx 에서 properties 유무 확인 후 definition state 설정함
