### PR TITLE
[feat][patch] 헬름 리포지트리 생성시 생성 페이지가 아니라 import 페이지가 렌더링 되는 현상 수정

### DIFF
--- a/frontend/public/components/default-resource.jsx
+++ b/frontend/public/components/default-resource.jsx
@@ -10,7 +10,7 @@ import { referenceFor, kindForReference, modelFor, k8sList } from '../module/k8s
 import { Kebab, kindObj, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading, Timestamp } from './utils';
 import { ResourceLabel } from '../models/hypercloud/resource-plural';
 import { useTranslation } from 'react-i18next';
-import { isResourceSchemaBasedMenu } from './hypercloud/form';
+import { isResourceSchemaBasedMenu, isResourceSchemaBasedOrCreateMenu } from './hypercloud/form';
 import { CustomResourceDefinitionModel } from '../models';
 
 const { common } = Kebab.factory;
@@ -105,7 +105,8 @@ DefaultPage.displayName = 'DefaultPage';
 export const DefaultDetailsPage = props => {
   const menuActions = [...Kebab.getExtensionsActionsForKind(kindObj(props.kind)), ...common];
   const [pageState, setPageState] = React.useState([navFactory.details(DetailsForKind(props.kind)), navFactory.editResource()]);
-  const isCustomResourceType = !isResourceSchemaBasedMenu(props.kindObj.kind);
+  const isCustomResourceType = !isResourceSchemaBasedOrCreateMenu(props.kindObj.kind);
+
   React.useEffect(() => {
     isCustomResourceType &&
       k8sList(CustomResourceDefinitionModel).then(res => {

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -22,7 +22,7 @@ import { NavBar } from '../utils/horizontal-nav';
 import { DefaultListComponent } from '../hypercloud/utils/default-list-component';
 import { getQueryArgument } from '../utils';
 import { CustomResourceDefinitionModel } from '../../models';
-import { isResourceSchemaBasedMenu } from '../hypercloud/form';
+import { isResourceSchemaBasedMenu, isResourceSchemaBasedOrCreateMenu } from '../hypercloud/form';
 
 /** @type {React.SFC<{disabled?: boolean, label?: string, onChange: (value: string) => void;, defaultValue?: string, value?: string, placeholder?: string, autoFocus?: boolean, onFocus?:any, name?:string, id?: string, onKeyDown?: any, parentClassName?: string }}>} */
 export const TextFilter = props => {
@@ -431,7 +431,8 @@ export const MultiListPage = props => {
     namespace: r.namespaced ? namespace : r.namespace,
     prop: r.prop || r.kind,
   }));
-  const isCustomResourceType = !isResourceSchemaBasedMenu(resources[0]?.kindObj?.kind);
+  const kind = props?.resources[0]?.kindObj?.kind || props?.resources[0]?.kind;
+  const isCustomResourceType = !isResourceSchemaBasedOrCreateMenu(kind);
   React.useEffect(() => {
     setCreatePropsState(createProps);
   }, [createProps]);
@@ -439,7 +440,7 @@ export const MultiListPage = props => {
     isCustomResourceType &&
       k8sList(CustomResourceDefinitionModel).then(res => {
         _.find(res, function(data) {
-          return data.spec.names.kind === resources[0]?.kindObj?.kind;
+          return data.spec.names.kind === kind;
         }) ||
           ((href = namespace ? `/k8s/ns/${namespace}/import` : `/k8s/all-namespaces/import`) && setCreatePropsState({ to: href }));
       });

--- a/frontend/public/components/hypercloud/form/index.ts
+++ b/frontend/public/components/hypercloud/form/index.ts
@@ -1,7 +1,7 @@
 import * as models from '../../../models';
 import { CustomResourceDefinitionModel } from '../../../models';
 import { allModels, getK8sAPIPath, K8sKind } from '../../../module/k8s';
-
+import * as helmModel from '../../../../public/models/hypercloud/helm-model';
 enum SCHEMA_DIRECTORY {
   MANAGEMENT = 'management',
   NETWORK = 'network',
@@ -41,11 +41,18 @@ export const resourceSchemaBasedMenuMap = new Map([
 
 const isCreateManualSet = new Set([models.RoleModel.kind, models.ClusterRoleModel.kind, models.ServiceInstanceModel.kind, models.TemplateInstanceModel.kind, models.TaskModel.kind, models.ClusterTaskModel.kind, models.TaskRunModel.kind, models.PipelineRunModel.kind, models.PipelineResourceModel.kind, models.RoleBindingModel.kind, models.ClusterRoleBindingModel.kind, models.RoleBindingClaimModel.kind, models.PipelineModel.kind, models.SecretModel.kind, models.ServiceBindingModel.kind]);
 
+const resourceCreateMenu = new Set([helmModel.HelmChartModel.kind, helmModel.HelmReleaseModel.kind, helmModel.HelmRepositoryModel.kind]);
+
 export const pluralToKind = (plural: string) => allModels().find(model => model.plural === plural)?.kind;
 
 export const isCreateManual = (kind: string) => isCreateManualSet.has(kind);
 
 export const isResourceSchemaBasedMenu = (kind: string) => resourceSchemaBasedMenuMap.has(kind);
+
+export const isResourceSchemaBasedOrCreateMenu = (kind: string) => {
+  const ret = resourceSchemaBasedMenuMap.has(kind) || resourceCreateMenu.has(kind);
+  return ret;
+};
 
 export const getResourceSchemaUrl = (model: K8sKind, isCustomResourceType: boolean) => {
   let url = null;


### PR DESCRIPTION
what:헬름 리포지트리, 헬름 릴리스, 롤 바인딩, 롤 생성시 생성 페이지가 아니라 import 페이지가 렌더링 되는 현상 수정
how: 헬름 관련 페이지는 개별적으로 생성페이지를 렌더링 하고있어서 이를 추가하였습니다.
롤 바인딩, 롤 페이지는 resources에 kindObj 없이 바로 kind 가 있어서 이를 참고할수 있는 코드로 수정하였습니다. 