### PR TITLE
[bugfix]헬름 릴리즈 페이지 수정시 오류페이지로 넘어가는 현상 수정

### DIFF
--- a/frontend/public/components/hypercloud/form/helmreleases/create-helmrelease.tsx
+++ b/frontend/public/components/hypercloud/form/helmreleases/create-helmrelease.tsx
@@ -151,7 +151,7 @@ const CreateHelmReleaseComponent: React.FC<HelmReleaseFormProps> = props => {
       versions.length > 0 && version.label !== ''
         ? versions.filter(e => {
             if (e.label === version.label) return true;
-          })[0].value
+          })[0]?.value
         : '';
     const setChartVersion = async () => {
       await coFetchJSON(`${host}/helm/v1/charts/${selectRepoName}_${selectChartName}/versions/${selectedVersion}`).then(res => {


### PR DESCRIPTION
<img width="844" alt="image" src="https://user-images.githubusercontent.com/82989054/211228817-99010a23-d7ec-45a7-8b7a-be7365fa0dff.png">
what: 헬름 릴리즈 페이지 수정시 오류페이지로 넘어가는 현상 수정하였습니다.
how: 페이지에 없는 인자를 사용하는 코드가 있어서 이를 수정했습니다.