### PR TITLE
[bugfix] dropdown callback 있을때만 실행하게 함, [bugfix] pipelinerun workspace sync-form-data 수정

### DIFF
--- a/frontend/public/components/hypercloud/form/pipelineruns/create-pipelinerun.tsx
+++ b/frontend/public/components/hypercloud/form/pipelineruns/create-pipelinerun.tsx
@@ -68,7 +68,7 @@ const ResourceListComponent = props => {
 };
 
 const WorkspaceListComponent = props => {
-  return props.workspaceList.map((cur, idx) => <Workspace namespace={props.namespace} methods={props.methods} id={`spec.workspaces[${idx}]`} {...cur} />);
+  return props.workspaceList.map((cur, idx) => <Workspace {...cur} key={`workspace-${cur.name}`} namespace={props.namespace} methods={props.methods} id={`spec.workspaces[${idx}]`} name={cur.name} />);
 };
 
 const CreatePipelineRunComponent: React.FC<PipelineRunFormProps> = props => {
@@ -176,7 +176,7 @@ const getCustomFormEditor = ({ match, kind, Form, isCreate }) => props => {
   const { formData, onChange } = props;
   const _formData = React.useMemo(() => convertToForm(formData), [formData]);
   const setFormData = React.useCallback(formData => onSubmitCallback(formData), [onSubmitCallback]);
-  const watchFieldNames = ['metadata.labels', 'spec.params', 'spec.resources'];
+  const watchFieldNames = ['metadata.labels', 'spec.params', 'spec.resources', 'spec.workspaces'];
   return <Form fixed={{ apiVersion: `${PipelineRunModel.apiGroup}/${PipelineRunModel.apiVersion}`, kind, metadata: { namespace: match.params.ns } }} explanation={''} titleVerb="Create" onSubmitCallback={onSubmitCallback} isCreate={isCreate} formData={_formData} setFormData={setFormData} onChange={onChange} watchFieldNames={watchFieldNames} />;
 };
 

--- a/frontend/public/components/hypercloud/form/utils/workspaces.tsx
+++ b/frontend/public/components/hypercloud/form/utils/workspaces.tsx
@@ -43,89 +43,85 @@ export const Workspace = props => {
   const { t } = useTranslation();
   const workspace = useWatch<string>({
     control: props.methods.control,
-    name: `${props.id}.name.${props.name}`,
+    name: `${props.id}.type`,
   });
-
-  const workspaceDetail = {
-    VolumeClaimTemplate: (
-      <>
-        <Section label={t('SINGLE:MSG_PIPELINERUNS_CREATEFORM_14')} id="accessMode">
-          <RadioGroup name={`${props.id}.volumeClaimTemplate.spec.accessModes`} items={accessItems} methods={props.methods} />
-        </Section>
-        <Section label={t('SINGLE:MSG_PIPELINERUNS_CREATEFORM_12')} id="storage">
-          <TextInput className="pf-c-form-control" id={`${props.id}.volumeClaimTemplate.spec.resources.requests.storage`} methods={props.methods} />
-        </Section>
-        <Section label={t('SINGLE:MSG_PIPELINERUNS_CREATEFORM_13')} id="storageClass">
-          <TextInput className="pf-c-form-control" id={`${props.id}.volumeClaimTemplate.spec.storageClassName`} methods={props.methods} />
-        </Section>
-      </>
-    ),
-    PVC: (
-      <>
-        <Section label={t('COMMON:MSG_LNB_MENU_141')} id="pvc">
-          <ResourceDropdown
-            name={`${props.id}.persistentVolumeClaim.claimName`}
-            resources={[
-              {
-                kind: 'PersistentVolumeClaim',
-                namespace: props.namespace,
-                prop: 'persistentvolumeclaim',
-              },
-            ]}
-            type="single"
-            methods={props.methods}
-            useHookForm
-          />
-        </Section>
-      </>
-    ),
-    ConfigMap: (
-      <>
-        <Section label={t('COMMON:MSG_LNB_MENU_120')} id="configmap">
-          <ResourceDropdown
-            name={`${props.id}.configmap.name`}
-            resources={[
-              {
-                kind: 'ConfigMap',
-                namespace: props.namespace,
-                prop: 'configmap',
-              },
-            ]}
-            type="single"
-            methods={props.methods}
-            useHookForm
-          />
-        </Section>
-      </>
-    ),
-    Secret: (
-      <>
-        <Section label={t('COMMON:MSG_LNB_MENU_119')} id="secret">
-          <ResourceDropdown
-            name={`${props.id}.secret.secretName`}
-            resources={[
-              {
-                kind: 'Secret',
-                namespace: props.namespace,
-                prop: 'secret',
-              },
-            ]}
-            type="single"
-            methods={props.methods}
-            useHookForm
-          />
-        </Section>
-      </>
-    ),
-    EmptyDirectory: null,
-  }[workspace];
 
   return (
     <ul>
+      <TextInput className="pf-c-form-control" id={`${props.id}.name`} methods={props.methods} defaultValue={props.name} hidden />
       <Section label={props.name} id={props.name}>
-        <Dropdown name={`${props.id}.name.${props.name}`} title={t('SINGLE:MSG_PIPELINERUNS_CREATEFORM_10')} items={workspaceType} defaultValue={props.type} />
+        <Dropdown name={`${props.id}.type`} title={t('SINGLE:MSG_PIPELINERUNS_CREATEFORM_10')} items={workspaceType} defaultValue={props.type} />
       </Section>
-      {workspaceDetail}
+      {workspace == 'VolumeClaimTemplate' && (
+        <>
+          <Section label={t('SINGLE:MSG_PIPELINERUNS_CREATEFORM_14')} id="accessMode">
+            <RadioGroup name={`${props.id}.volumeClaimTemplate.spec.accessModes[0]`} items={accessItems} methods={props.methods} />
+          </Section>
+          <Section label={t('SINGLE:MSG_PIPELINERUNS_CREATEFORM_12')} id="storage">
+            <TextInput className="pf-c-form-control" id={`${props.id}.volumeClaimTemplate.spec.resources.requests.storage`} methods={props.methods} />
+          </Section>
+          <Section label={t('SINGLE:MSG_PIPELINERUNS_CREATEFORM_13')} id="storageClass">
+            <TextInput className="pf-c-form-control" id={`${props.id}.volumeClaimTemplate.spec.storageClassName`} methods={props.methods} />
+          </Section>
+        </>
+      )}
+      {workspace == 'PVC' && (
+        <>
+          <Section label={t('COMMON:MSG_LNB_MENU_141')} id="pvc">
+            <ResourceDropdown
+              name={`${props.id}.persistentVolumeClaim.claimName`}
+              resources={[
+                {
+                  kind: 'PersistentVolumeClaim',
+                  namespace: props.namespace,
+                  prop: 'persistentvolumeclaim',
+                },
+              ]}
+              type="single"
+              methods={props.methods}
+              useHookForm
+            />
+          </Section>
+        </>
+      )}
+      {workspace == 'ConfigMap' && (
+        <>
+          <Section label={t('COMMON:MSG_LNB_MENU_120')} id="configmap">
+            <ResourceDropdown
+              name={`${props.id}.configmap.name`}
+              resources={[
+                {
+                  kind: 'ConfigMap',
+                  namespace: props.namespace,
+                  prop: 'configmap',
+                },
+              ]}
+              type="single"
+              methods={props.methods}
+              useHookForm
+            />
+          </Section>
+        </>
+      )}
+      {workspace == 'Secret' && (
+        <>
+          <Section label={t('COMMON:MSG_LNB_MENU_119')} id="secret">
+            <ResourceDropdown
+              name={`${props.id}.secret.secretName`}
+              resources={[
+                {
+                  kind: 'Secret',
+                  namespace: props.namespace,
+                  prop: 'secret',
+                },
+              ]}
+              type="single"
+              methods={props.methods}
+              useHookForm
+            />
+          </Section>
+        </>
+      )}
     </ul>
   );
 };

--- a/frontend/public/components/hypercloud/utils/dropdown.tsx
+++ b/frontend/public/components/hypercloud/utils/dropdown.tsx
@@ -86,7 +86,7 @@ const Dropdown_: React.SFC<DropdownProps> = props => {
 
     setValue(name, selected);
     setKeyboardHoverKey(selected);
-    callback(selected);
+    callback && callback(selected);
 
     hide(e);
   };


### PR DESCRIPTION
[bugfix] dropdown callback 있을때만 실행하게 함
- dropdown callback 있을때만 실행하게 함

[bugfix] pipelinerun workspace sync-form-data 수정

form 에서 yaml 이동할때 workspaces 변환 되도록 함
추가 개선 필요점
- Volume Claim Template 외는 yaml -> form 돌아올때 값 사라짐
- Volume Claim Template 라디오 버튼 선택시 멈췄다가 나중에 선택될때가 있음