### PR TITLE
[feat][patch]태스크 생성시 볼륨 팝업에서 타입 선택후에도 selectbox열려있는 현상 수정

### DIFF
--- a/frontend/public/components/hypercloud/utils/dropdown.tsx
+++ b/frontend/public/components/hypercloud/utils/dropdown.tsx
@@ -27,7 +27,23 @@ type DropdownRowProps = {
 };
 
 const Dropdown_: React.SFC<DropdownProps> = props => {
-  const { name, ariaLabel, className, buttonClassName, menuClassName, dropDownClassName, titlePrefix, describedBy, disabled, required, methods, defaultValue, callback } = props;
+  const {
+    name,
+    ariaLabel,
+    className,
+    buttonClassName,
+    menuClassName,
+    dropDownClassName,
+    titlePrefix,
+    describedBy,
+    disabled,
+    required,
+    methods,
+    defaultValue,
+    callback = e => {
+      e;
+    },
+  } = props;
   const { register, unregister, setValue, watch } = methods ? methods : useFormContext();
 
   const selectedKey = watch(name, defaultValue);


### PR DESCRIPTION
what: 태스크 생성시 볼륨 팝업에서 타입 선택후에도 selectbox열려있는 현상 수정하였습니다.
why: 함수 props를 전달해주지 않아서 undefined 에 인자를 전달해줘서 생기는 문제 해결 
