### PR TITLE
[feat][patch]헬름 리포지터리의 이름 클릭시 라우팅되는 기능 구현

### DIFF
--- a/frontend/public/components/hypercloud/helmchart.tsx
+++ b/frontend/public/components/hypercloud/helmchart.tsx
@@ -5,6 +5,7 @@ import { SectionHeading, Timestamp, detailsPage, navFactory, ResourceLink } from
 import { TableProps } from './utils/default-list-component';
 import { DetailsPage, ListPage, DetailsPageProps } from '../factory';
 import { HelmChartModel, HelmRepositoryModel } from '@console/internal/models/hypercloud/helm-model';
+import { Link } from 'react-router-dom';
 
 const kind = HelmChartModel.kind;
 
@@ -127,7 +128,10 @@ export const HelmChartDetailsList: React.FC<HelmChartDetailsListProps> = ({ entr
       )}
       <dt>{t('SINGLE:MSG_HELMCHARTS_HELMCHARTDETAILS_TABDETAILS_1')}</dt>
       <dd>
-        <div>{t('SINGLE:MSG_HELMCHARTS_HELMCHARTDETAILS_TABDETAILS_2') + ' : ' + entry.repo.name}</div>
+        <div>
+          <span>{t('SINGLE:MSG_HELMCHARTS_HELMCHARTDETAILS_TABDETAILS_2') + ' : '}</span>
+          <Link to={`/helmrepositories/${entry.repo.name}`}>{entry.repo.name}</Link>
+        </div>
         <div>{'URL : ' + entry.repo.url}</div>
       </dd>
       <dt>{t('SINGLE:MSG_HELMCHARTS_HELMCHARTDETAILS_TABDETAILS_6')}</dt>


### PR DESCRIPTION
what: 헬름 리포지터리의 이름 클릭시 라우팅되는 기능 구현하였습니다.
<img width="1069" alt="image" src="https://user-images.githubusercontent.com/82989054/211690133-34711c32-eff7-4e15-974c-dda6cebd162e.png">
