### PR TITLE
[feat][patch] 레디스 클러스터 마스터 컨피그맵, 슬래이브 컨피그맵 없을시 resource아이콘 뜨는 경우 수정

### DIFF
--- a/frontend/public/components/hypercloud/redis-cluster.tsx
+++ b/frontend/public/components/hypercloud/redis-cluster.tsx
@@ -60,10 +60,10 @@ const tableProps: TableProps = {
       children: obj.spec.clusterSize,
     },
     {
-      children: <ResourceLink kind={'ConfigMap'} name={obj.spec.redisLeader.redisConfig?.additionalRedisConfig} namespace={obj.metadata.namespace} title={obj.spec.redisLeader.redisConfig?.additionalRedisConfig} />,
+      children: obj.spec.redisLeader.redisConfig?.additionalRedisConfig ? <ResourceLink kind={'ConfigMap'} name={obj.spec.redisLeader.redisConfig?.additionalRedisConfig} namespace={obj.metadata.namespace} title={obj.spec.redisLeader.redisConfig?.additionalRedisConfig} /> : '-',
     },
     {
-      children: <ResourceLink kind={'ConfigMap'} name={obj.spec.redisFollower.redisConfig?.additionalRedisConfig} namespace={obj.metadata.namespace} title={obj.spec.redisFollower.redisConfig?.additionalRedisConfig} />,
+      children: obj.spec.redisFollower.redisConfig?.additionalRedisConfig ? <ResourceLink kind={'ConfigMap'} name={obj.spec.redisFollower.redisConfig?.additionalRedisConfig} namespace={obj.metadata.namespace} title={obj.spec.redisFollower.redisConfig?.additionalRedisConfig} /> : '-',
     },
     {
       children: <Timestamp timestamp={obj.metadata.creationTimestamp} />,

--- a/scripts/run-console.sh
+++ b/scripts/run-console.sh
@@ -3,8 +3,7 @@
 set -exuo pipefail
 
 #myIP=$(hostname -I | awk '{print $1}')
-# myIP=$(ipconfig getifaddr en0)
-myIP='192.168.7.25'
+myIP=$(ipconfig getifaddr en0)
 # myIP=localhost
 ## Default K8S Endpoint is public POC environment
 # k8sIP='220.90.208.100'

--- a/scripts/run-console.sh
+++ b/scripts/run-console.sh
@@ -3,7 +3,8 @@
 set -exuo pipefail
 
 #myIP=$(hostname -I | awk '{print $1}')
-myIP=$(ipconfig getifaddr en0)
+# myIP=$(ipconfig getifaddr en0)
+myIP='192.168.7.25'
 # myIP=localhost
 ## Default K8S Endpoint is public POC environment
 # k8sIP='220.90.208.100'


### PR DESCRIPTION
레디스 클러스터 마스터 컨피그맵, 슬래이브 컨피그맵 없을시 resource아이콘 뜨는 경우 수정하였습니다.
레디스 클러스터 마스터 컨피그맵, 슬래이브 컨피그맵 없을시 사진처럼 아이콘없이 -을 삽입하였습니다.
<img width="1377" alt="스크린샷 2023-01-17 오후 1 04 19" src="https://user-images.githubusercontent.com/82989054/212808117-4fb9cb7e-7613-4613-8ea8-c1750179d119.png">
(사진은 한개만 바꾸어서 설명했지만 실제로는 둘다 수정하였습니다.)