### PR TITLE
[feat][patch] volumeclaimtemplate을 제외한 pvc, secret, configmap, emptydir의 경우 form view <-> yaml view 타입을 여러번 변경하는 경우 워크스페이스 하위 리소스가 초기화 되는 현상 해결

### DIFF
--- a/frontend/public/components/hypercloud/form/pipelineruns/create-pipelinerun.tsx
+++ b/frontend/public/components/hypercloud/form/pipelineruns/create-pipelinerun.tsx
@@ -146,10 +146,9 @@ const CreatePipelineRunComponent: React.FC<PipelineRunFormProps> = props => {
       )}
       {!_.isEmpty(workspaceList) && (
         <Section label={t('SINGLE:MSG_PIPELINERUNS_CREATEFORM_9')} id="workspace">
-          <WorkspaceListComponent workspaceList={workspaceList} namespace={namespace} methods={methods} />
+          <WorkspaceListComponent workspaceList={workspaceList} namespace={namespace} methods={methods} formData={formData} />
         </Section>
       )}
-
       <div className="co-form-section__separator" />
 
       <Section label={t('SINGLE:MSG_TASKRUN_CREATFORM_DIV2_17')} id="serviceaccount">
@@ -174,10 +173,22 @@ const CreatePipelineRunComponent: React.FC<PipelineRunFormProps> = props => {
 
 const getCustomFormEditor = ({ match, kind, Form, isCreate }) => props => {
   const { formData, onChange } = props;
-  const _formData = React.useMemo(() => convertToForm(formData), [formData]);
-  const setFormData = React.useCallback(formData => onSubmitCallback(formData), [onSubmitCallback]);
+  const [formDataState, setFormDataState] = React.useState(convertToForm(formData));
+  const [formDatas, setFormDatas] = React.useState(() => formData_ => {
+    return onSubmitCallback(formData_);
+  });
+
+  React.useEffect(() => {
+    setFormDatas(() => formData => onSubmitCallback(formData));
+  }, [onSubmitCallback]);
+
+  React.useEffect(() => {
+    setFormDataState(convertToForm(formData));
+  }, [formData]);
+
   const watchFieldNames = ['metadata.labels', 'spec.params', 'spec.resources', 'spec.workspaces'];
-  return <Form fixed={{ apiVersion: `${PipelineRunModel.apiGroup}/${PipelineRunModel.apiVersion}`, kind, metadata: { namespace: match.params.ns } }} explanation={''} titleVerb="Create" onSubmitCallback={onSubmitCallback} isCreate={isCreate} formData={_formData} setFormData={setFormData} onChange={onChange} watchFieldNames={watchFieldNames} />;
+
+  return <Form fixed={{ apiVersion: `${PipelineRunModel.apiGroup}/${PipelineRunModel.apiVersion}`, kind, metadata: { namespace: match.params.ns } }} explanation={''} titleVerb="Create" onSubmitCallback={onSubmitCallback} isCreate={isCreate} formData={formDataState} setFormData={formDatas} onChange={onChange} watchFieldNames={watchFieldNames} />;
 };
 
 export const CreatePipelineRun: React.FC<CreatePipelineRunProps> = props => {

--- a/frontend/public/components/hypercloud/form/utils/workspaces.tsx
+++ b/frontend/public/components/hypercloud/form/utils/workspaces.tsx
@@ -46,8 +46,8 @@ export const Workspace = props => {
     name: `${props.id}.type`,
   });
   const [pvcDefaultValue, setPvcDefaultValue] = React.useState(props.persistentVolumeClaim?.claimName);
-  const [cmDefaultValue, setCmDefaultValue] = React.useState(props.persistentVolumeClaim?.claimName);
-  const [secretDefaultValue, setsecretDefaultValue] = React.useState(props.persistentVolumeClaim?.claimName);
+  const [cmDefaultValue, setCmDefaultValue] = React.useState(props.configmap?.name);
+  const [secretDefaultValue, setsecretDefaultValue] = React.useState(props.secret?.secretName);
 
   React.useEffect(() => {
     props.persistentVolumeClaim?.claimName && setPvcDefaultValue(props.persistentVolumeClaim?.claimName);

--- a/frontend/public/components/hypercloud/form/utils/workspaces.tsx
+++ b/frontend/public/components/hypercloud/form/utils/workspaces.tsx
@@ -45,7 +45,19 @@ export const Workspace = props => {
     control: props.methods.control,
     name: `${props.id}.type`,
   });
+  const [pvcDefaultValue, setPvcDefaultValue] = React.useState(props.persistentVolumeClaim?.claimName);
+  const [cmDefaultValue, setCmDefaultValue] = React.useState(props.persistentVolumeClaim?.claimName);
+  const [secretDefaultValue, setsecretDefaultValue] = React.useState(props.persistentVolumeClaim?.claimName);
 
+  React.useEffect(() => {
+    props.persistentVolumeClaim?.claimName && setPvcDefaultValue(props.persistentVolumeClaim?.claimName);
+  }, [props.persistentVolumeClaim?.claimName]);
+  React.useEffect(() => {
+    props.configmap?.name && setCmDefaultValue(props.configmap?.name);
+  }, [props.configmap?.name]);
+  React.useEffect(() => {
+    props.secret?.secretName && setsecretDefaultValue(props.secret?.secretName);
+  }, [props.secret?.secretName]);
   return (
     <ul>
       <TextInput className="pf-c-form-control" id={`${props.id}.name`} methods={props.methods} defaultValue={props.name} hidden />
@@ -79,6 +91,7 @@ export const Workspace = props => {
               ]}
               type="single"
               methods={props.methods}
+              defaultValue={pvcDefaultValue}
               useHookForm
             />
           </Section>
@@ -98,6 +111,7 @@ export const Workspace = props => {
               ]}
               type="single"
               methods={props.methods}
+              defaultValue={cmDefaultValue}
               useHookForm
             />
           </Section>
@@ -117,6 +131,7 @@ export const Workspace = props => {
               ]}
               type="single"
               methods={props.methods}
+              defaultValue={secretDefaultValue}
               useHookForm
             />
           </Section>


### PR DESCRIPTION
volumeclaimtemplate을 제외한 pvc, secret, configmap, emptydir의 경우 form view <-> yaml view 타입을 여러번 변경하는 경우 워크스페이스 하위 리소스가 초기화 되는 현상 해결 하였습니다. 
복합적인 여러 원인이 있었습니다.
form view 작성후에 yaml view 로 바꾼다음 form view 으로 돌아올때 
formData는 정상적으로 전달을 받는데 반해서 
useForm의 내부의 데이터가 유실되는 현상이 되었고 
formData는 정상적으로 돌아오기 때문에 
state는 그대로 유지되어 모든 것이 정상작동을 하는것 처럼 보이지만 
form view <-> yaml view 타입을 한번 더 변경을 할때
 useForm의 내부의 데이터가 유실되었던 것을 확인하는 
 getvalue()작업에서 유실이 확인되어 3번 왔다갔다하는 현상이 발견되었습니다.
이를 해결하기 위해 defaultValue 의 값을 주어 useForm의 내부의 데이터가 유실되는 현상을 막았지만
useCallback의 훅이 사용되었는데 이를 사용하고 전해진 함수에서 사용이 될때 얉은 복사가 되어 props로 전달되지 않았습니다.
useMemo도 useCallback과 마찬가지 문제가 일어났습니다.
이를 수정하여 useEffect 와 useEffect를 사용해 props로 바꾸었지만
9~ 34번정도 form view <-> yaml view의 타입을 변경하면 하위 리소스가 유실되는 경우를 발견하였습니다.
이는 props.persistentVolumeClaim.claimName, props.configmap.name, props.secret.secretName 가 동기적으로 바뀌기 때문에 처음에는 undefined 가 되어 props으로 전달이 되는데 이가 바뀌어도 함수 자체를 프롭스로 받기 때문에 
리렌더링이 안되어서 이 변수가 동기적으로 변하는 props라고 표시(useState, useEffect)를 해주어서 문제를 해결했습니다.