### PR TITLE
[feat][patch][ims290754] form view <-> yaml view 타입을 여러번 변경하는 경우 emptydir 워크스페이스 타입이 초기화 되는 현상수정 및 taskSpec.workspaces가 없는 경우 태스크런 리소스 이름 클릭 시 에러가 발생하는 현상 수정

### DIFF
--- a/frontend/public/components/hypercloud/form/utils/workspaces.tsx
+++ b/frontend/public/components/hypercloud/form/utils/workspaces.tsx
@@ -62,7 +62,7 @@ export const Workspace = props => {
     <ul>
       <TextInput className="pf-c-form-control" id={`${props.id}.name`} methods={props.methods} defaultValue={props.name} hidden />
       <Section label={props.name} id={props.name}>
-        <Dropdown name={`${props.id}.type`} title={t('SINGLE:MSG_PIPELINERUNS_CREATEFORM_10')} items={workspaceType} defaultValue={props.type} />
+        <Dropdown name={`${props.id}.type`} title={t('SINGLE:MSG_PIPELINERUNS_CREATEFORM_10')} items={workspaceType} defaultValue={workspace} />
       </Section>
       {workspace == 'VolumeClaimTemplate' && (
         <>

--- a/frontend/public/components/hypercloud/task-run.tsx
+++ b/frontend/public/components/hypercloud/task-run.tsx
@@ -66,7 +66,7 @@ const TaskRunTableRow: RowFunction<K8sResourceKind> = ({ obj: taskRun, index, ke
 
 const TaskRunDetails: React.FC<TaskRunDetailsProps> = ({ obj: taskRun }) => {
   const { t } = useTranslation();
-  const renderSecrets = taskRun.spec.workspaces.filter(data => !!data.secret).map(secret => secret.secret.secretName) || [];
+  const renderSecrets = taskRun.spec?.workspaces?.filter(data => !!data.secret).map(secret => secret.secret.secretName) || [];
 
   return (
     <>


### PR DESCRIPTION
 1. form view <-> yaml view 타입을 여러번 변경하는 경우 emptydir 워크스페이스 타입이 초기화 되는 현상수정 하였습니다.
 2. taskSpec.workspaces가 없는 경우 태스크런 리소스 이름 클릭 시 에러가 발생하는 현상 수정하였습니다.