### PR TITLE
[bugfix][patch]ims296608 status필드없어도 에러발생하지 않도록 수정

### DIFF
--- a/frontend/public/components/hypercloud/kafkamirrormaker2.tsx
+++ b/frontend/public/components/hypercloud/kafkamirrormaker2.tsx
@@ -30,9 +30,9 @@ export const MirrorRow = ({ mirror, km2 }) => {
       <div className="col-lg-2 col-md-3 col-sm-5 col-xs-7">{mirror.sourceCluster || '-'}</div>
       <div className="col-lg-2 col-md-2 col-sm-3 hidden-xs ">{targetClusterBootstrapServerObj.bootstrapServers}</div>
       <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">{mirror.targetCluster || '-'}</div>
-      <div className="col-lg-2 col-md-2 hidden-sm hidden-xs ">{connector.name}</div>
+      <div className="col-lg-2 col-md-2 hidden-sm hidden-xs ">{connector?.name || '-'}</div>
       <div className="col-lg-1 hidden-md hidden-sm hid den-xs ">
-        <Status status={connector.connector.state} />
+        <Status status={connector?.connector?.state || '-'} />
       </div>
     </div>
   );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/66113237/219334063-9f27193d-eafa-4d90-806c-2b2786d93b4d.png)

카프카 미러메이커2 화면에서 status값 없어도 에러화면 뜨지 않도록 수정 