### PR TITLE
[feat][patch] 커넥터 이름 help-icon추가 및 카프카 미러메이커2 이중 테이블 구성및 이중테이블 정렬구현

### DIFF
--- a/frontend/public/components/hypercloud/kafkamirrormaker2.tsx
+++ b/frontend/public/components/hypercloud/kafkamirrormaker2.tsx
@@ -7,7 +7,9 @@ import { ResourceLabel } from '../../models/hypercloud/resource-plural';
 import { useTranslation } from 'react-i18next';
 import { Status } from '@console/shared';
 import { SingleExpandableTable } from './utils/expandable-table';
-import { compoundExpand, sortable } from '@patternfly/react-table';
+import { compoundExpand } from '@patternfly/react-table';
+import { Tooltip } from '@patternfly/react-core';
+import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 const kind = KafkaMirrorMaker2Model.kind;
 const menuActions: KebabAction[] = [...Kebab.factory.common];
 
@@ -26,13 +28,13 @@ export const MirrorRow = ({ mirror, km2 }) => {
   });
   return (
     <div className="row">
-      <div className="col-lg-2 col-md-3 col-sm-4 col-xs-5 ">{sourceClusterBootstrapServerObj.bootstrapServers}</div>
+      <div className="col-lg-2 col-md-3 col-sm-4 col-xs-5 ">{sourceClusterBootstrapServerObj?.bootstrapServers}</div>
       <div className="col-lg-2 col-md-3 col-sm-5 col-xs-7">{mirror.sourceCluster || '-'}</div>
-      <div className="col-lg-2 col-md-2 col-sm-3 hidden-xs ">{targetClusterBootstrapServerObj.bootstrapServers}</div>
+      <div className="col-lg-2 col-md-2 col-sm-3 hidden-xs ">{targetClusterBootstrapServerObj?.bootstrapServers}</div>
       <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">{mirror.targetCluster || '-'}</div>
-      <div className="col-lg-2 col-md-2 hidden-sm hidden-xs ">{connector.name}</div>
+      <div className="col-lg-2 col-md-2 hidden-sm hidden-xs ">{connector?.name}</div>
       <div className="col-lg-1 hidden-md hidden-sm hid den-xs ">
-        <Status status={connector.connector.state} />
+        <Status status={connector?.connector?.state} />
       </div>
     </div>
   );
@@ -47,7 +49,13 @@ export const MirrorTable = ({ data, km2 }) => {
           <div className="col-lg-2 col-md-3 col-sm-5 col-xs-7">{t('MULTI:MSG_DEVELOPER_KAFKAMIRRORMAKER2_KAFKAMIRRORMAKER2DETAILS_TABDETAILS_6')}</div>
           <div className="col-lg-2 col-md-2 col-sm-3 hidden-xs">{t('MULTI:MSG_DEVELOPER_KAFKAMIRRORMAKER2_KAFKAMIRRORMAKER2DETAILS_TABDETAILS_7')}</div>
           <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">{t('MULTI:MSG_DEVELOPER_KAFKAMIRRORMAKER2_KAFKAMIRRORMAKER2DETAILS_TABDETAILS_8')}</div>
-          <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">{t('MULTI:MSG_DEVELOPER_KAFKAMIRRORMAKER2_KAFKAMIRRORMAKER2DETAILS_TABDETAILS_9')}</div>
+          <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">
+            {t('MULTI:MSG_DEVELOPER_KAFKAMIRRORMAKER2_KAFKAMIRRORMAKER2DETAILS_TABDETAILS_9')}
+            {'  '}
+            <Tooltip content={[<span key={`mirror-table-tooltip-${km2.index}`}>커넥터 정보가 유효하지 않을 시 해당 값은 불러오기가 불가능한 상태입니다</span>]}>
+              <HelpIcon className="co-field-level-help__icon" />
+            </Tooltip>
+          </div>
           <div className="col-lg-1 hidden-md hidden-sm hidden-xs">{t('MULTI:MSG_DEVELOPER_KAFKAMIRRORMAKER2_KAFKAMIRRORMAKER2DETAILS_TABDETAILS_10')}</div>
         </div>
         <div className="co-m-table-grid__body">
@@ -66,24 +74,24 @@ const KafkaMirrorMaker2Table = (t, props) => {
   const KafkaMirrorMaker2Columns = [
     {
       title: t('COMMON:MSG_MAIN_TABLEHEADER_1'),
-      transforms: [sortable],
+      sortField: 'metadata.name',
       data: 'name',
     },
     {
       title: t('COMMON:MSG_MAIN_TABLEHEADER_2'),
-      transforms: [sortable],
+      sortField: 'metadata.name',
       data: 'namespace',
     },
     {
       title: t('COMMON:MSG_MAIN_TABLEHEADER_151'),
-      transforms: [sortable],
+      sortField: 'spec.obj.spec.mirrors',
       tooltip: 'MSG_MAIN_TABLEHEADER_152',
       cellTransforms: [compoundExpand],
       data: 'mirrors.length',
     },
     {
       title: t('COMMON:MSG_MAIN_TABLEHEADER_12'),
-      transforms: [sortable],
+      sortField: 'metadata.creationTimestamp',
       data: 'creationTimestamp',
     },
     {
@@ -98,10 +106,11 @@ const KafkaMirrorMaker2Table = (t, props) => {
     return [
       {
         title: <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.uid} />,
+        index: index,
       },
       {
         className: 'co-break-word',
-        title: <ResourceLink kind="Namespace" name={obj.metadata.namespace} title={obj.metadata.namespace} />,
+        title: <ResourceLink kind="Namespace" name={obj.metadata.namespace} namespace={obj.metadata.namespace} title={obj.metadata.namespace} />,
       },
       {
         title: obj.spec.mirrors.length,
@@ -110,7 +119,7 @@ const KafkaMirrorMaker2Table = (t, props) => {
         },
       },
       {
-        title: <Timestamp timestamp={obj.metadata.creationTimestamp} />,
+        title: <Timestamp timestamp={obj.metadata.creationTimestamp} creationTimestamp={obj.metadata.creationTimestamp} />,
       },
       {
         className: Kebab.columnClass,

--- a/frontend/public/components/hypercloud/kafkamirrormaker2.tsx
+++ b/frontend/public/components/hypercloud/kafkamirrormaker2.tsx
@@ -32,15 +32,9 @@ export const MirrorRow = ({ mirror, km2 }) => {
       <div className="col-lg-2 col-md-3 col-sm-5 col-xs-7">{mirror.sourceCluster || '-'}</div>
       <div className="col-lg-2 col-md-2 col-sm-3 hidden-xs ">{targetClusterBootstrapServerObj?.bootstrapServers}</div>
       <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">{mirror.targetCluster || '-'}</div>
-<<<<<<< HEAD
-      <div className="col-lg-2 col-md-2 hidden-sm hidden-xs ">{connector?.name}</div>
-      <div className="col-lg-1 hidden-md hidden-sm hid den-xs ">
-        <Status status={connector?.connector?.state} />
-=======
       <div className="col-lg-2 col-md-2 hidden-sm hidden-xs ">{connector?.name || '-'}</div>
       <div className="col-lg-1 hidden-md hidden-sm hid den-xs ">
         <Status status={connector?.connector?.state || '-'} />
->>>>>>> 463990062f39cf4be80a66984fdcbe08c3dd6e5d
       </div>
     </div>
   );

--- a/frontend/public/components/utils/_field-level-help.scss
+++ b/frontend/public/components/utils/_field-level-help.scss
@@ -9,4 +9,15 @@
     color: var(--pf-global--Color--dark-200);
     font-size: 12px;
   }
+
+  &:hover .co-field-level-help__icon_padding {
+    left: 5px;
+    color: var(--pf-global--Color--dark-100);
+  }
+
+  .co-field-level-help__icon_padding {
+    color: var(--pf-global--Color--dark-200);
+    left: 5px;
+    font-size: 12px;
+  }
 }

--- a/frontend/public/components/utils/timestamp.tsx
+++ b/frontend/public/components/utils/timestamp.tsx
@@ -159,6 +159,7 @@ export type TimestampProps = {
   simple?: boolean;
   omitSuffix?: boolean;
   className?: string;
+  creationTimestamp?: string;
 };
 
 Timestamp.displayName = 'Timestamp';


### PR DESCRIPTION
커넥터 이름 help-icon추가 및 카프카 미러메이커2 이중 테이블 구성및 이중테이블 정렬구현하였습니다.
"커넥터 정보가 유효하지 않을 시 해당 값은 불러오기가 불가능한 상태입니다" 문구는 스트링 추가후 수정할 예정입니다.
