### PR TITLE
[patch][feat]kafkarebalance > kafka cluster 객체찾는 방식 변경

### DIFF
--- a/frontend/public/components/hypercloud/kafkarebalance.tsx
+++ b/frontend/public/components/hypercloud/kafkarebalance.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import { K8sResourceKind, resourceURL } from '../../module/k8s';
+import { k8sGet, K8sResourceKind, resourceURL } from '../../module/k8s';
 import { DetailsPage, ListPage, DetailsPageProps } from '../factory';
 import { DetailsItem, Kebab, KebabAction, detailsPage, Timestamp, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from '../utils';
 import { KafkaClusterModel, KafkaRebalanceModel } from '../../models';
 import { ResourceLabel } from '../../models/hypercloud/resource-plural';
 import { useTranslation } from 'react-i18next';
 import { TableProps } from './utils/default-list-component';
-import { k8sList } from '@console/internal/module/k8s';
 import { Status } from '@console/shared';
 import { CodeContainer } from '../utils/hypercloud/code-container';
 import { coFetchJSON } from '@console/internal/co-fetch';
@@ -104,15 +103,7 @@ export const KafkaRebalanceDetailsList: React.FC<KafkaRebalanceDetailsListProps>
 
   React.useEffect(() => {
     const fetchKafkaConfig = async () => {
-      await k8sList(KafkaClusterModel, {
-        ns: namespace,
-        labelSelector: {
-          matchLabels: {
-            'strimzi.io/cluster': kafkaName,
-          },
-        },
-      }).then(res => {
-        const kafka = res[0];
+      await k8sGet(KafkaClusterModel, kafkaName, namespace).then(kafka => {
         setConfig(kafka.spec?.cruiseControl?.config);
         setLoading(true);
       });


### PR DESCRIPTION
kafka rebalnce에서 필요한 kafka cluster를 찾는 방식 변경 

기존: kafka List 를 가져온후 label이  'strimzi.io/cluster:kafka클러스터이름'와 일치하는 객체 찾음.
현재 : kafka get 서비스를 통해 이름으로 검색.

기본방법의 경우 사용자가 리밸런스 객체 생성 후 다시 kafka의 label을 설정해주어야 한다는 번거로움이 있어 수정