### PR TITLE
[feat][patch] 노드 상세 페이지 및 컨트롤러 상세 페이지 구성

### DIFF
--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -185,14 +185,14 @@ const AppContents_: React.FC<AppContentsProps> = ({ activePerspective }) => (
           <LazyRoute path="/sas-app/:name" exact loader={() => import('./hypercloud/sas/sas-app' /* webpackChunkName: "sas-app" */).then(m => m.SasAppsDetailsPage)} />
 
           <LazyRoute path="/sas-service" exact loader={() => import('./hypercloud/sas/sas-service' /* webpackChunkName: "sas-service" */).then(m => m.SasServicePage)} />
-          <LazyRoute path="/sas-app/:name" exact loader={() => import('./hypercloud/sas/sas-service' /* webpackChunkName: "sas-app" */).then(m => m.SasControllersDetailsPage)} />
+          <LazyRoute path="/sas-service/:name" exact loader={() => import('./hypercloud/sas/sas-service' /* webpackChunkName: "sas-app" */).then(m => m.SasControllersDetailsPage)} />
 
           <LazyRoute path="/sas-controller" exact loader={() => import('./hypercloud/sas/sas-controller' /* webpackChunkName: "sas-controller" */).then(m => m.SasControllerPage)} />
           <LazyRoute path="/sas-controller/~new" exact loader={() => import('./hypercloud/sas/create-sas-controller' /* webpackChunkName: "sas-app" */).then(m => m.CreateSasController)} />
-          <LazyRoute path="/sas-app/:name" exact loader={() => import('./hypercloud/sas/sas-controller' /* webpackChunkName: "sas-app" */).then(m => m.SasControllersDetailsPage)} />
+          <LazyRoute path="/sas-controller/:name" exact loader={() => import('./hypercloud/sas/sas-controller' /* webpackChunkName: "sas-app" */).then(m => m.SasControllersDetailsPage)} />
 
           <LazyRoute path="/sas-node" exact loader={() => import('./hypercloud/sas/sas-node' /* webpackChunkName: "sas-node" */).then(m => m.SasNodePage)} />
-          <LazyRoute path="/sas-app/:name" exact loader={() => import('./hypercloud/sas/sas-node' /* webpackChunkName: "sas-app" */).then(m => m.SasNodeDetailsPage)} />
+          <LazyRoute path="/sas-node/:name" exact loader={() => import('./hypercloud/sas/sas-node' /* webpackChunkName: "sas-app" */).then(m => m.SasNodeDetailsPage)} />
 
           <LazyRoute path="/kiali/all-namespaces" exact loader={() => import('./hypercloud/kiali' /* webpackChunkName: "kiali" */).then(m => NamespaceFromURL(m.KialiPage))} />
           <LazyRoute path="/kiali/ns/:ns" exact loader={() => import('./hypercloud/kiali' /* webpackChunkName: "kiali" */).then(m => NamespaceFromURL(m.KialiPage))} />

--- a/frontend/public/components/hypercloud/sas/sas-node.tsx
+++ b/frontend/public/components/hypercloud/sas/sas-node.tsx
@@ -4,9 +4,9 @@ import { AwxStatusReducer } from '@console/dev-console/src/utils/hc-status-reduc
 import { Status } from '@console/shared';
 import { useTranslation } from 'react-i18next';
 // import { TFunction } from 'i18next';
-import { DetailsItem, detailsPage, Kebab, KebabAction, navFactory, ResourceLink, ResourceSummary, SectionHeading, Timestamp } from '../../utils';
+import { DetailsItem, detailsPage, Kebab, NavBar, navFactory, PageHeading, ResourceLink, ResourceSummary, SectionHeading, Timestamp } from '../../utils';
 import { K8sResourceKind } from '../../../module/k8s';
-import { DetailsPage, DetailsPageProps } from '../../factory';
+import { DetailsPageProps } from '../../factory';
 import { WebSocketContext } from '../../app';
 import { Button, Modal } from '@patternfly/react-core';
 import '../utils/help.scss';
@@ -16,7 +16,6 @@ import { DropdownToggle, DropdownToggleCheckbox } from '@patternfly/react-core';
 import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
 import { SingleSasTable } from './sas-single-table';
 
-const menuActions: KebabAction[] = [...Kebab.factory.common];
 const kind = 'SasController';
 
 const SasKebab = ({ status, handleModalToggle, data }) => {
@@ -91,7 +90,7 @@ const SasControllerTable = props => {
   const rowRenderer = (index, obj) => {
     return [
       {
-        title: <ResourceLink kind={kind} name={obj.HOSTNAME} namespace={obj.HOSTNAME} title={obj.HOSTNAME} />,
+        title: <ResourceLink kind={kind} name={obj.HOSTNAME} namespace={obj.HOSTNAME} title={obj.HOSTNAME} manualPath={`/sas-node/${obj.HOSTNAME}`} />,
         index: index,
       },
       {
@@ -307,11 +306,65 @@ const SasNodeDetails: React.FC<AWXDetailsProps> = ({ obj: awx }) => {
   );
 };
 
-const { details, editResource } = navFactory;
+const { details } = navFactory;
 
 export const SasNodeDetailsPage: React.FC<DetailsPageProps> = props => {
-  const [url, setUrl] = React.useState(null);
-  return <DetailsPage {...props} kind={kind} menuActions={menuActions} customData={{ label: 'URL', url: url ? `https://${url}` : null }} customStatePath="spec.hostname" setCustomState={setUrl} getResourceStatus={AwxStatusReducer} pages={[details(detailsPage(SasNodeDetails)), editResource()]} />;
+  const { name } = props.match.params;
+  const [appName, setAppName] = React.useState(name);
+  const webSocket = React.useContext(WebSocketContext);
+  const [data, setData] = React.useState([]);
+  const [singleData, setSingleData] = React.useState(null);
+  React.useEffect(() => {
+    webSocket.ws?.send(`{ header: { targetServiceName: 'com.tmax.superobject.admin.master.GetWorker', messageType: 'REQUEST', contentType: 'TEXT' }, body: {poolId : 'default', getAll : 'true', describe : 'true'} }`);
+  }, [webSocket]);
+  webSocket.ws &&
+    webSocket.ws.onmessage(msg => {
+      // eslint-disable-next-line no-console
+      console.log('Message from server~!', msg);
+      setData(msg.body.formattedBody.items);
+    });
+
+  React.useEffect(() => {
+    setAppName(name);
+  }, [name]);
+  React.useEffect(() => {
+    data.map(item => {
+      if (item.HOSTNAME === appName) {
+        setSingleData(item);
+      }
+    });
+  }, [data, name]);
+  React.useEffect(() => {
+    console.log(123123, singleData);
+  }, [singleData]);
+
+  return (
+    <div>
+      <PageHeading detail={true} title={appName} badge={props.badge} icon={props.icon}></PageHeading>
+      <div className={'co-m-page__body'}>
+        <div className="co-m-horizontal-nav">{<NavBar pages={[details(detailsPage(SasNodeDetails))]} baseURL={props.match.url} basePath={props.match.path} />}</div>
+      </div>
+      <div className="co-m-pane__body">
+        <SectionHeading text={'앱 상세'} />
+        <div className="row">
+          <div className="col-lg-6">
+            <dt>이름</dt>
+            <dd>{appName}</dd>
+            <dt>생성 일시</dt>
+            <dd>{singleData?.CREATED_AT}</dd>
+          </div>
+          <div className="col-lg-6">
+            <dt>상태</dt>
+            <Status status={singleData?.STATUS} />
+            <dt>타입</dt>
+            <dd>{singleData?.TYPE}</dd>
+            <dt>워커 노드 풀</dt>
+            <dd>{singleData?.POOL_ID}</dd>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 type ImageSummaryProps = {

--- a/frontend/public/components/hypercloud/sas/sas-service.tsx
+++ b/frontend/public/components/hypercloud/sas/sas-service.tsx
@@ -4,9 +4,9 @@ import { AwxStatusReducer } from '@console/dev-console/src/utils/hc-status-reduc
 import { Status } from '@console/shared';
 import { useTranslation } from 'react-i18next';
 // import { TFunction } from 'i18next';
-import { DetailsItem, detailsPage, Kebab, KebabAction, navFactory, ResourceLink, ResourceSummary, SectionHeading } from '../../utils';
+import { DetailsItem, detailsPage, Kebab, NavBar, navFactory, PageHeading, ResourceLink, ResourceSummary, SectionHeading } from '../../utils';
 import { K8sResourceKind } from '../../../module/k8s';
-import { DetailsPage, DetailsPageProps } from '../../factory';
+import { DetailsPageProps } from '../../factory';
 import { WebSocketContext } from '../../app';
 import { Button, Modal } from '@patternfly/react-core';
 import '../utils/help.scss';
@@ -16,7 +16,6 @@ import { DropdownToggle, DropdownToggleCheckbox } from '@patternfly/react-core';
 import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
 import { SingleSasTable } from './sas-single-table';
 
-const menuActions: KebabAction[] = [...Kebab.factory.common];
 const kind = 'SasController';
 
 const SasKebab = ({ status, handleModalToggle, data }) => {
@@ -305,11 +304,67 @@ const SasControllerDetails: React.FC<AWXDetailsProps> = ({ obj: awx }) => {
   );
 };
 
-const { details, editResource } = navFactory;
+const { details } = navFactory;
 
 export const SasControllersDetailsPage: React.FC<DetailsPageProps> = props => {
-  const [url, setUrl] = React.useState(null);
-  return <DetailsPage {...props} kind={kind} menuActions={menuActions} customData={{ label: 'URL', url: url ? `https://${url}` : null }} customStatePath="spec.hostname" setCustomState={setUrl} getResourceStatus={AwxStatusReducer} pages={[details(detailsPage(SasControllerDetails)), editResource()]} />;
+  const { name } = props.match.params;
+  const [appName, setAppName] = React.useState(name);
+  const webSocket = React.useContext(WebSocketContext);
+  const [data, setData] = React.useState([]);
+  const [singleData, setSingleData] = React.useState(null);
+  React.useEffect(() => {
+    webSocket.ws?.send(`{ header: { targetServiceName: 'com.tmax.superobject.admin.master.GetApplicationConsole', messageType: 'REQUEST', contentType: 'TEXT' }, body: {poolId : 'default', getAll : 'true', describe : 'true'} }`);
+  }, [webSocket]);
+  webSocket.ws &&
+    webSocket.ws.onmessage(msg => {
+      // eslint-disable-next-line no-console
+      console.log('Message from server~!', msg);
+      setData(msg.body.formattedBody.items);
+    });
+
+  React.useEffect(() => {
+    setAppName(name);
+  }, [name]);
+  React.useEffect(() => {
+    data.map(item => {
+      if (item.APP_NAME === appName) {
+        setSingleData(item);
+      }
+    });
+  }, [data, name]);
+  React.useEffect(() => {
+    console.log(123123, singleData);
+  }, [singleData]);
+
+  return (
+    <div>
+      <PageHeading detail={true} title={appName} badge={props.badge} icon={props.icon}></PageHeading>
+      <div className={'co-m-page__body'}>
+        <div className="co-m-horizontal-nav">{<NavBar pages={[details(detailsPage(SasControllerDetails))]} baseURL={props.match.url} basePath={props.match.path} />}</div>
+      </div>
+      <div className="co-m-pane__body">
+        <SectionHeading text={'앱 상세'} />
+        <div className="row">
+          <div className="col-lg-6">
+            <dt>이름</dt>
+            <dd>{appName}</dd>
+            <dt>생성 일시</dt>
+            <dd>{singleData?.CREATED_AT}</dd>
+          </div>
+          <div className="col-lg-6">
+            <dt>상태</dt>
+            <Status status={singleData?.STATUS} />
+            <dt>배포버전</dt>
+            <dd>{singleData?.ACTIVATE_VERSION}</dd>
+            <dt>레플리카수</dt>
+            <dd>{singleData?.REPLICAS}</dd>
+            <dt>타겟 워커 노드 풀</dt>
+            <dd>{singleData?.POOL_ID}</dd>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 type ImageSummaryProps = {


### PR DESCRIPTION
노드 상세 페이지 및 컨트롤러 상세 페이지 구성
<img width="1328" alt="스크린샷 2023-03-14 오후 1 19 02" src="https://user-images.githubusercontent.com/82989054/224892616-24cc8587-a97f-479f-867c-9669b0f13b47.png">
<img width="1310" alt="스크린샷 2023-03-14 오후 1 12 10" src="https://user-images.githubusercontent.com/82989054/224892620-7dba9578-e00b-4e9a-9da2-70f173664394.png">
