### PR TITLE
[feat][patch][IMS 300246] 상단 메뉴 탭 우측 기준으로 나오게함

### DIFF
--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -63,7 +63,7 @@ export const DropdownGroups = () => {
       <QuestionCircleIcon color="white" />
     </span>
   );
-  return <ApplicationLauncher aria-label="User menu" data-test="user-dropdown" className="co-app-launcher" onSelect={onSelect} onToggle={onToggle} isOpen={isOpen} items={dropdownItems} toggleIcon={helpToggle} color="white" isGrouped />;
+  return <ApplicationLauncher aria-label="User menu" data-test="user-dropdown" className="co-app-launcher" onSelect={onSelect} onToggle={onToggle} isOpen={isOpen} items={dropdownItems} position="right" toggleIcon={helpToggle} color="white" isGrouped />;
 };
 const SystemStatusButton = ({ statuspageData, className }) =>
   !_.isEmpty(_.get(statuspageData, 'incidents')) ? (


### PR DESCRIPTION
[feat][patch][IMS 300246] 상단 메뉴 탭 우측 기준으로 나오게함

![image](https://user-images.githubusercontent.com/48277126/227888516-81e3e260-7ad4-4ea7-b487-109e85775590.png)
id 가 짧아 지면 잘리는 현상 확인

![image](https://user-images.githubusercontent.com/48277126/227888724-0b8fa5af-d76d-4c62-bf05-3182ec844faf.png)
우측에 있는 메뉴인지 옵션으로 지정해줌으로써 문제 해결함