### PR TITLE
[bugfix][patch] ingress 주소 안나옴 수정

### DIFF
--- a/frontend/public/components/ingress.jsx
+++ b/frontend/public/components/ingress.jsx
@@ -29,7 +29,7 @@ const getHosts = ingress => {
 
 export const ingressIp = ingress => {
   const ingressList = ingress.status?.loadBalancer?.ingress;
-  return ingressList && ingressList.length > 1 ? ingressList[0].ip : null;
+  return ingressList && ingressList.length > 0 ? ingressList[0].ip : null;
 };
 
 const getAddresses = ingress => {


### PR DESCRIPTION
비어있는지 확인하는 것이었으나 판별식에 오류가 있어서 1개 일때도 아무것도 보여주지 않는 문제가 있었음