### PR TITLE
[feat] sample map 의 key 를 edit-yaml.jsx 에서 번역되도록 함

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -443,6 +443,10 @@ export const EditYAML_ = connect(stateToProps)(
       const options = { readOnly, scrollBeyondLastLine: false };
       const model = this.getModel(obj);
       const { samples, snippets } = model ? getResourceSidebarSamples(model, yamlSamplesList) : { samples: [], snippets: [] };
+      const translatedSample = samples.map((s)=>{
+        return {...s, title: t(s.title), description: t(s.description)}
+        }
+      );
       const showSchema = definition && !_.isEmpty(definition);
       const hasSidebarContent = showSchema || !_.isEmpty(samples) || !_.isEmpty(snippets);
       const sidebarLink =
@@ -519,7 +523,7 @@ export const EditYAML_ = connect(stateToProps)(
                   </div>
                 </div>
               </div>
-              {hasSidebarContent && <ResourceSidebar definition={definition} isCreateMode={create} kindObj={model} loadSampleYaml={this.replaceYamlContent_} insertSnippetYaml={this.insertYamlContent_} downloadSampleYaml={this.downloadSampleYaml_} showSidebar={showSidebar} toggleSidebar={this.toggleSidebar} samples={samples} snippets={snippets} showSchema={showSchema} />}
+              {hasSidebarContent && <ResourceSidebar definition={definition} isCreateMode={create} kindObj={model} loadSampleYaml={this.replaceYamlContent_} insertSnippetYaml={this.insertYamlContent_} downloadSampleYaml={this.downloadSampleYaml_} showSidebar={showSidebar} toggleSidebar={this.toggleSidebar} samples={translatedSample} snippets={snippets} showSchema={showSchema} />}
             </div>
           </div>
         </div>


### PR DESCRIPTION
sample map 에는 key 넣고 edit-yaml.jsx 에서 translate 함수 실행하게 수정

getResourceSidebarSamples 에서는 useTranslation, withTranslation 등이 되지 않아서 key 만 넣고  edit-yaml.jsx 에서 translate 함수 실행하게 수정

번역 key는 추후 추가될 예정