### PR TITLE
[feat][patch] tmaxcloud.org 외 다른 도메인에서 credentials include 포함되어야 하므로 임시로 조치함

### DIFF
--- a/frontend/public/co-fetch.js
+++ b/frontend/public/co-fetch.js
@@ -102,7 +102,9 @@ const getCSRFToken = () =>
     .pop();
 
 const isCallToSubdomain = (url = '') => {
-  return new RegExp('[a-z]+\\.tmaxcloud\\.org+').test(url) && !url.includes(location.host);
+  // tmaxcloud.org 외 다른 도메인에서도 가능해야 하므로 임시로 조치함
+  // return new RegExp('[a-z]+\\.tmaxcloud\\.org+').test(url) && !url.includes(location.host);
+  return !url.includes(location.host);
 };
 
 export const coFetch = (url, options = {}, timeout = 60000) => {


### PR DESCRIPTION
[feat][patch] tmaxcloud.org 외 다른 도메인에서 credentials include 포함되어야 하므로 임시로 조치함

오승주 연구원 요청

콘솔에서 multicluster라는 subdomain으로 요청을 보내야 하는 경우 현재 

크로스 오리진에 대한 쿠키 처리(credentials: 'include')가 누락 되는 것이 관찰됨

원인
```
const isCallToSubdomain = (url = '') => {
  return new RegExp('[a-z]+\\.tmaxcloud\\.org+').test(url) && !url.includes(location.host);
};
```

하드코딩되어 있어 [[tmaxcloud.org](http://tmaxcloud.org/)](http://tmaxcloud.org) 도메인이 아니면 안됨

(오승주 연구원 환경 주소 - [https://console.192.168.109.21.nip.io/](https://console.192.168.109.21.nip.io/))

다른 global domain을 사용해도 credential이 추가가 되도록 요청

조치
tmaxcloud.org RegExp 부분 뺌
다른 문제 발생 등 확인되면 다시 확인할 필요 있음